### PR TITLE
Simplify tank tiles entities

### DIFF
--- a/src/main/java/com/indemnity83/irontanks/common/Content.java
+++ b/src/main/java/com/indemnity83/irontanks/common/Content.java
@@ -3,7 +3,6 @@ package com.indemnity83.irontanks.common;
 import com.indemnity83.irontanks.IronTanks;
 import com.indemnity83.irontanks.common.blocks.BlockIronTank;
 import com.indemnity83.irontanks.common.blocks.IronTankType;
-import com.indemnity83.irontanks.common.entities.*;
 import com.indemnity83.irontanks.common.items.ItemIronTank;
 import com.indemnity83.irontanks.common.items.TankChangerType;
 import net.minecraft.client.renderer.block.model.ModelResourceLocation;

--- a/src/main/java/com/indemnity83/irontanks/common/Content.java
+++ b/src/main/java/com/indemnity83/irontanks/common/Content.java
@@ -19,7 +19,8 @@ public final class Content {
         GameRegistry.register(ironTankBlock);
         GameRegistry.register(ironTankItemBlock);
 
-        for(IronTankType type : IronTankType.VALUES) {
+        for (IronTankType type : IronTankType.VALUES) {
+            if (type.tileEntity == null) continue;
             GameRegistry.registerTileEntity(type.tileEntity, type.tileEntityId);
         }
     }

--- a/src/main/java/com/indemnity83/irontanks/common/Content.java
+++ b/src/main/java/com/indemnity83/irontanks/common/Content.java
@@ -2,6 +2,7 @@ package com.indemnity83.irontanks.common;
 
 import com.indemnity83.irontanks.IronTanks;
 import com.indemnity83.irontanks.common.blocks.BlockIronTank;
+import com.indemnity83.irontanks.common.blocks.IronTankType;
 import com.indemnity83.irontanks.common.entities.*;
 import com.indemnity83.irontanks.common.items.ItemIronTank;
 import com.indemnity83.irontanks.common.items.TankChangerType;
@@ -19,12 +20,9 @@ public final class Content {
         GameRegistry.register(ironTankBlock);
         GameRegistry.register(ironTankItemBlock);
 
-        GameRegistry.registerTileEntity(TileEntityCopperTank.class, "copper_tank_tile_entity");
-        GameRegistry.registerTileEntity(TileEntityDiamondTank.class, "diamond_tank_tile_entity");
-        GameRegistry.registerTileEntity(TileEntityGoldTank.class, "gold_tank_tile_entity");
-        GameRegistry.registerTileEntity(TileEntityIronTank.class, "iron_tank_tile_entity");
-        GameRegistry.registerTileEntity(TileEntityObsidianTank.class, "obsidian_tank_tile_entity");
-        GameRegistry.registerTileEntity(TileEntitySilverTank.class, "silver_tank_tile_entity");
+        for(IronTankType type : IronTankType.VALUES) {
+            GameRegistry.registerTileEntity(type.tileEntity, type.tileEntityId);
+        }
     }
 
     public static void registerItems() {

--- a/src/main/java/com/indemnity83/irontanks/common/blocks/IronTankType.java
+++ b/src/main/java/com/indemnity83/irontanks/common/blocks/IronTankType.java
@@ -28,12 +28,14 @@ public enum IronTankType implements IStringSerializable {
     public final int capacity;
     private final Collection<String> materials;
     private final Collection<String> recipes;
-    private final Class<? extends TileEntityIronTank> tileEntity;
+    public final Class<? extends TileEntityTank> tileEntity;
+    public final String tileEntityId;
 
-    IronTankType(int capacity, Class<? extends TileEntityIronTank> tileEntity, Collection<String> materials, Collection<String> recipes) {
+    IronTankType(int capacity, Class<? extends TileEntityTank> tileEntity, Collection<String> materials, Collection<String> recipes) {
         this.capacity = capacity;
-        this.tileEntity = tileEntity;
         this.name = this.name().toLowerCase();
+        this.tileEntity = tileEntity;
+        this.tileEntityId = this.name + "_tank_tile_entity";
         this.materials = materials;
         this.recipes = recipes;
     }

--- a/src/main/java/com/indemnity83/irontanks/common/blocks/IronTankType.java
+++ b/src/main/java/com/indemnity83/irontanks/common/blocks/IronTankType.java
@@ -1,7 +1,7 @@
 package com.indemnity83.irontanks.common.blocks;
 
 import buildcraft.api.BCBlocks;
-import com.indemnity83.irontanks.common.entities.*;
+import com.indemnity83.irontanks.common.tiles.*;
 import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
@@ -16,22 +16,22 @@ import java.util.Collections;
 public enum IronTankType implements IStringSerializable {
 
     GLASS(16, null, Collections.EMPTY_LIST, Collections.EMPTY_LIST),
-    COPPER(27, TileEntityCopperTank.class, Collections.singleton("ingotCopper"), Collections.singleton("GGGMTMGGG")),
-    IRON(32, TileEntityIronTank.class, Arrays.asList("ingotIron", "ingotRefinedIron"), Arrays.asList("GMGMTMGMG", "GGGM0MGGG")),
-    SILVER(43, TileEntitySilverTank.class, Collections.singleton("ingotSilver"), Arrays.asList("GMGM0MGMG", "GGGM1MGGG")),
-    GOLD(48, TileEntityGoldTank.class, Collections.singleton("ingotGold"), Arrays.asList("GMGM1MGMG", "GGGM2MGGG")),
-    DIAMOND(64, TileEntityDiamondTank.class, Collections.singleton("gemDiamond"), Arrays.asList("GGGG2GMMM", "GGGM3MGGG")),
-    OBSIDIAN(64, TileEntityObsidianTank.class, Collections.singleton("obsidian"), Collections.singleton("MMMM4MMMM"));
+    COPPER(27, TileCopperTank.class, Collections.singleton("ingotCopper"), Collections.singleton("GGGMTMGGG")),
+    IRON(32, TileIronTank.class, Arrays.asList("ingotIron", "ingotRefinedIron"), Arrays.asList("GMGMTMGMG", "GGGM0MGGG")),
+    SILVER(43, TileSilverTank.class, Collections.singleton("ingotSilver"), Arrays.asList("GMGM0MGMG", "GGGM1MGGG")),
+    GOLD(48, TileGoldTank.class, Collections.singleton("ingotGold"), Arrays.asList("GMGM1MGMG", "GGGM2MGGG")),
+    DIAMOND(64, TileDiamondTank.class, Collections.singleton("gemDiamond"), Arrays.asList("GGGG2GMMM", "GGGM3MGGG")),
+    OBSIDIAN(64, TileObsidianTank.class, Collections.singleton("obsidian"), Collections.singleton("MMMM4MMMM"));
 
     public static final IronTankType VALUES[] = values();
     public final String name;
     public final int capacity;
     private final Collection<String> materials;
     private final Collection<String> recipes;
-    public final Class<? extends TileEntityTank> tileEntity;
+    public final Class<? extends TileTank> tileEntity;
     public final String tileEntityId;
 
-    IronTankType(int capacity, Class<? extends TileEntityTank> tileEntity, Collection<String> materials, Collection<String> recipes) {
+    IronTankType(int capacity, Class<? extends TileTank> tileEntity, Collection<String> materials, Collection<String> recipes) {
         this.capacity = capacity;
         this.name = this.name().toLowerCase();
         this.tileEntity = tileEntity;
@@ -81,17 +81,17 @@ public enum IronTankType implements IStringSerializable {
     public TileEntity makeEntity() {
         switch (this) {
             case IRON:
-                return new TileEntityIronTank();
+                return new TileIronTank();
             case GOLD:
-                return new TileEntityGoldTank();
+                return new TileGoldTank();
             case DIAMOND:
-                return new TileEntityDiamondTank();
+                return new TileDiamondTank();
             case COPPER:
-                return new TileEntityCopperTank();
+                return new TileCopperTank();
             case SILVER:
-                return new TileEntitySilverTank();
+                return new TileSilverTank();
             case OBSIDIAN:
-                return new TileEntityObsidianTank();
+                return new TileObsidianTank();
             default:
                 return null;
         }

--- a/src/main/java/com/indemnity83/irontanks/common/entities/TileEntityCopperTank.java
+++ b/src/main/java/com/indemnity83/irontanks/common/entities/TileEntityCopperTank.java
@@ -1,14 +1,9 @@
 package com.indemnity83.irontanks.common.entities;
 
 import com.indemnity83.irontanks.common.blocks.IronTankType;
-import net.minecraftforge.fluids.Fluid;
 
-public class TileEntityCopperTank extends TileEntityIronTank {
-
-    public TileEntityCopperTank() {
-        super();
-
-        int capacity = Fluid.BUCKET_VOLUME * IronTankType.COPPER.capacity;
-        this.tank.setCapacity(capacity);
+public class TileEntityCopperTank extends TileEntityTank {
+    int getCapacity() {
+        return IronTankType.COPPER.capacity;
     }
 }

--- a/src/main/java/com/indemnity83/irontanks/common/entities/TileEntityDiamondTank.java
+++ b/src/main/java/com/indemnity83/irontanks/common/entities/TileEntityDiamondTank.java
@@ -1,13 +1,9 @@
 package com.indemnity83.irontanks.common.entities;
 
 import com.indemnity83.irontanks.common.blocks.IronTankType;
-import net.minecraftforge.fluids.Fluid;
 
-public class TileEntityDiamondTank extends TileEntityIronTank {
-    public TileEntityDiamondTank() {
-        super();
-
-        int capacity = Fluid.BUCKET_VOLUME * IronTankType.DIAMOND.capacity;
-        this.tank.setCapacity(capacity);
+public class TileEntityDiamondTank extends TileEntityTank {
+    int getCapacity() {
+        return IronTankType.IRON.capacity;
     }
 }

--- a/src/main/java/com/indemnity83/irontanks/common/entities/TileEntityGoldTank.java
+++ b/src/main/java/com/indemnity83/irontanks/common/entities/TileEntityGoldTank.java
@@ -1,13 +1,9 @@
 package com.indemnity83.irontanks.common.entities;
 
 import com.indemnity83.irontanks.common.blocks.IronTankType;
-import net.minecraftforge.fluids.Fluid;
 
-public class TileEntityGoldTank extends TileEntityIronTank {
-    public TileEntityGoldTank() {
-        super();
-
-        int capacity = Fluid.BUCKET_VOLUME * IronTankType.GOLD.capacity;
-        this.tank.setCapacity(capacity);
+public class TileEntityGoldTank extends TileEntityTank {
+    int getCapacity() {
+        return IronTankType.GOLD.capacity;
     }
 }

--- a/src/main/java/com/indemnity83/irontanks/common/entities/TileEntityIronTank.java
+++ b/src/main/java/com/indemnity83/irontanks/common/entities/TileEntityIronTank.java
@@ -1,15 +1,9 @@
 package com.indemnity83.irontanks.common.entities;
 
-import buildcraft.factory.tile.TileTank;
 import com.indemnity83.irontanks.common.blocks.IronTankType;
-import net.minecraftforge.fluids.Fluid;
 
-public class TileEntityIronTank extends TileTank {
-
-    public TileEntityIronTank() {
-        super();
-
-        int capacity = Fluid.BUCKET_VOLUME * IronTankType.IRON.capacity;
-        this.tank.setCapacity(capacity);
+public class TileEntityIronTank extends TileEntityTank {
+    int getCapacity() {
+        return IronTankType.IRON.capacity;
     }
 }

--- a/src/main/java/com/indemnity83/irontanks/common/entities/TileEntityObsidianTank.java
+++ b/src/main/java/com/indemnity83/irontanks/common/entities/TileEntityObsidianTank.java
@@ -1,13 +1,9 @@
 package com.indemnity83.irontanks.common.entities;
 
 import com.indemnity83.irontanks.common.blocks.IronTankType;
-import net.minecraftforge.fluids.Fluid;
 
-public class TileEntityObsidianTank extends TileEntityIronTank {
-    public TileEntityObsidianTank() {
-        super();
-
-        int capacity = Fluid.BUCKET_VOLUME * IronTankType.OBSIDIAN.capacity;
-        this.tank.setCapacity(capacity);
+public class TileEntityObsidianTank extends TileEntityTank {
+    int getCapacity() {
+        return IronTankType.OBSIDIAN.capacity;
     }
 }

--- a/src/main/java/com/indemnity83/irontanks/common/entities/TileEntitySilverTank.java
+++ b/src/main/java/com/indemnity83/irontanks/common/entities/TileEntitySilverTank.java
@@ -1,13 +1,9 @@
 package com.indemnity83.irontanks.common.entities;
 
 import com.indemnity83.irontanks.common.blocks.IronTankType;
-import net.minecraftforge.fluids.Fluid;
 
-public class TileEntitySilverTank extends TileEntityIronTank {
-    public TileEntitySilverTank() {
-        super();
-
-        int capacity = Fluid.BUCKET_VOLUME * IronTankType.SILVER.capacity;
-        this.tank.setCapacity(capacity);
+public class TileEntitySilverTank extends TileEntityTank {
+    int getCapacity() {
+        return IronTankType.IRON.capacity;
     }
 }

--- a/src/main/java/com/indemnity83/irontanks/common/entities/TileEntityTank.java
+++ b/src/main/java/com/indemnity83/irontanks/common/entities/TileEntityTank.java
@@ -1,0 +1,23 @@
+package com.indemnity83.irontanks.common.entities;
+
+import buildcraft.factory.tile.TileTank;
+
+public abstract class TileEntityTank extends TileTank {
+
+    abstract int getCapacity();
+
+    TileEntityTank() {
+        super();
+
+        this.tank.setCapacity(getCapacity());
+    }
+
+    // This method is actually implemented in TileTank
+    // but a quirk of making an abstract class that extends
+    // a concrete class, which implements interfaces is I can't
+    // just call super.update(). Maybe my Java skills just aren't
+    // good enough yet...
+    public void update() {
+        smoothedTank.tick(getWorld());
+    }
+}

--- a/src/main/java/com/indemnity83/irontanks/common/tiles/TileCopperTank.java
+++ b/src/main/java/com/indemnity83/irontanks/common/tiles/TileCopperTank.java
@@ -1,8 +1,8 @@
-package com.indemnity83.irontanks.common.entities;
+package com.indemnity83.irontanks.common.tiles;
 
 import com.indemnity83.irontanks.common.blocks.IronTankType;
 
-public class TileEntityCopperTank extends TileEntityTank {
+public class TileCopperTank extends TileTank {
     int getCapacity() {
         return IronTankType.COPPER.capacity;
     }

--- a/src/main/java/com/indemnity83/irontanks/common/tiles/TileDiamondTank.java
+++ b/src/main/java/com/indemnity83/irontanks/common/tiles/TileDiamondTank.java
@@ -1,8 +1,8 @@
-package com.indemnity83.irontanks.common.entities;
+package com.indemnity83.irontanks.common.tiles;
 
 import com.indemnity83.irontanks.common.blocks.IronTankType;
 
-public class TileEntityDiamondTank extends TileEntityTank {
+public class TileDiamondTank extends TileTank {
     int getCapacity() {
         return IronTankType.IRON.capacity;
     }

--- a/src/main/java/com/indemnity83/irontanks/common/tiles/TileGoldTank.java
+++ b/src/main/java/com/indemnity83/irontanks/common/tiles/TileGoldTank.java
@@ -1,8 +1,8 @@
-package com.indemnity83.irontanks.common.entities;
+package com.indemnity83.irontanks.common.tiles;
 
 import com.indemnity83.irontanks.common.blocks.IronTankType;
 
-public class TileEntityGoldTank extends TileEntityTank {
+public class TileGoldTank extends TileTank {
     int getCapacity() {
         return IronTankType.GOLD.capacity;
     }

--- a/src/main/java/com/indemnity83/irontanks/common/tiles/TileIronTank.java
+++ b/src/main/java/com/indemnity83/irontanks/common/tiles/TileIronTank.java
@@ -1,8 +1,8 @@
-package com.indemnity83.irontanks.common.entities;
+package com.indemnity83.irontanks.common.tiles;
 
 import com.indemnity83.irontanks.common.blocks.IronTankType;
 
-public class TileEntityIronTank extends TileEntityTank {
+public class TileIronTank extends TileTank {
     int getCapacity() {
         return IronTankType.IRON.capacity;
     }

--- a/src/main/java/com/indemnity83/irontanks/common/tiles/TileObsidianTank.java
+++ b/src/main/java/com/indemnity83/irontanks/common/tiles/TileObsidianTank.java
@@ -1,8 +1,8 @@
-package com.indemnity83.irontanks.common.entities;
+package com.indemnity83.irontanks.common.tiles;
 
 import com.indemnity83.irontanks.common.blocks.IronTankType;
 
-public class TileEntityObsidianTank extends TileEntityTank {
+public class TileObsidianTank extends TileTank {
     int getCapacity() {
         return IronTankType.OBSIDIAN.capacity;
     }

--- a/src/main/java/com/indemnity83/irontanks/common/tiles/TileSilverTank.java
+++ b/src/main/java/com/indemnity83/irontanks/common/tiles/TileSilverTank.java
@@ -1,8 +1,8 @@
-package com.indemnity83.irontanks.common.entities;
+package com.indemnity83.irontanks.common.tiles;
 
 import com.indemnity83.irontanks.common.blocks.IronTankType;
 
-public class TileEntitySilverTank extends TileEntityTank {
+public class TileSilverTank extends TileTank {
     int getCapacity() {
         return IronTankType.IRON.capacity;
     }

--- a/src/main/java/com/indemnity83/irontanks/common/tiles/TileTank.java
+++ b/src/main/java/com/indemnity83/irontanks/common/tiles/TileTank.java
@@ -1,12 +1,10 @@
-package com.indemnity83.irontanks.common.entities;
+package com.indemnity83.irontanks.common.tiles;
 
-import buildcraft.factory.tile.TileTank;
-
-public abstract class TileEntityTank extends TileTank {
+public abstract class TileTank extends buildcraft.factory.tile.TileTank {
 
     abstract int getCapacity();
 
-    TileEntityTank() {
+    TileTank() {
         super();
 
         this.tank.setCapacity(getCapacity());

--- a/src/main/java/com/indemnity83/irontanks/common/tiles/TileTank.java
+++ b/src/main/java/com/indemnity83/irontanks/common/tiles/TileTank.java
@@ -1,13 +1,20 @@
 package com.indemnity83.irontanks.common.tiles;
 
+import net.minecraftforge.fluids.Fluid;
+
 public abstract class TileTank extends buildcraft.factory.tile.TileTank {
 
+    /**
+     * Get the capacity of the tank in buckets.
+     *
+     * @return int capacity in buckets
+     */
     abstract int getCapacity();
 
     TileTank() {
         super();
 
-        this.tank.setCapacity(getCapacity());
+        this.tank.setCapacity(getCapacity() * Fluid.BUCKET_VOLUME);
     }
 
     // This method is actually implemented in TileTank


### PR DESCRIPTION
There was a lot of duplicate code going on around the tile entities, as well as some unnecessary long class names. This PR aims to simplify a couple things:

1. When creating a new Tank, it's no longer necessary to register the tile entity with the game explicitly (it will be done based on the data provided in the IronTankType enum)
2. Tile entity classes are moved from the "entities" package to a "tiles" package
3. Class names simplified to just "TileIronTank" format, removing the word "Entity" from the class