### PR TITLE
Block Rendering And Proxy Updates

### DIFF
--- a/src/main/java/com/indemnity83/irontanks/IronTanks.java
+++ b/src/main/java/com/indemnity83/irontanks/IronTanks.java
@@ -31,11 +31,10 @@ public class IronTanks {
      */
     @EventHandler
     public void preInit(FMLPreInitializationEvent event) {
-        proxy.preInit(event);
-
         Content.registerBlocks();
         Content.registerItems();
-        Content.registerRenders();
+
+        proxy.preInit(event);
     }
 
     /**
@@ -46,9 +45,9 @@ public class IronTanks {
      */
     @EventHandler
     public void init(FMLInitializationEvent event) {
-        proxy.init(event);
-
         IronTankType.registerRecipes(Content.ironTankBlock);
+
+        proxy.init(event);
     }
 
     /**

--- a/src/main/java/com/indemnity83/irontanks/client/ClientProxy.java
+++ b/src/main/java/com/indemnity83/irontanks/client/ClientProxy.java
@@ -1,7 +1,29 @@
 package com.indemnity83.irontanks.client;
 
+import com.indemnity83.irontanks.IronTanks;
 import com.indemnity83.irontanks.common.CommonProxy;
+import com.indemnity83.irontanks.common.Content;
+import com.indemnity83.irontanks.common.blocks.IronTankType;
+import com.indemnity83.irontanks.common.items.TankChangerType;
+import net.minecraft.client.renderer.block.model.ModelResourceLocation;
+import net.minecraft.item.Item;
+import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.client.model.ModelLoader;
+import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
 
 public class ClientProxy extends CommonProxy {
+    @Override
+    public void preInit(FMLPreInitializationEvent event) {
+        super.preInit(event);
 
+        Item tankItem = Item.getItemFromBlock(Content.ironTankBlock);
+
+        for (IronTankType type : IronTankType.VALUES) {
+            ModelLoader.setCustomModelResourceLocation(tankItem, type.metaValue, new ModelResourceLocation(Content.ironTankItemBlock.getRegistryName(), "variant=" + type.name));
+        }
+
+        for (TankChangerType type : TankChangerType.VALUES) {
+            ModelLoader.setCustomModelResourceLocation(type.item, 0, new ModelResourceLocation(new ResourceLocation(IronTanks.MODID, "iron_tank_upgrades"), "variant=" + type.itemName));
+        }
+    }
 }

--- a/src/main/java/com/indemnity83/irontanks/common/Content.java
+++ b/src/main/java/com/indemnity83/irontanks/common/Content.java
@@ -1,19 +1,15 @@
 package com.indemnity83.irontanks.common;
 
-import com.indemnity83.irontanks.IronTanks;
 import com.indemnity83.irontanks.common.blocks.BlockIronTank;
 import com.indemnity83.irontanks.common.blocks.IronTankType;
 import com.indemnity83.irontanks.common.items.ItemIronTank;
 import com.indemnity83.irontanks.common.items.TankChangerType;
-import net.minecraft.client.renderer.block.model.ModelResourceLocation;
-import net.minecraft.util.ResourceLocation;
-import net.minecraftforge.client.model.ModelLoader;
 import net.minecraftforge.fml.common.registry.GameRegistry;
 
 public final class Content {
 
     public static BlockIronTank ironTankBlock = new BlockIronTank();
-    private static ItemIronTank ironTankItemBlock = new ItemIronTank(ironTankBlock);
+    public static ItemIronTank ironTankItemBlock = new ItemIronTank(ironTankBlock);
 
     public static void registerBlocks() {
         GameRegistry.register(ironTankBlock);
@@ -28,17 +24,4 @@ public final class Content {
     public static void registerItems() {
         TankChangerType.buildItems();
     }
-
-    public static void registerRenders() {
-        for (TankChangerType type : TankChangerType.VALUES) {
-            ModelLoader.setCustomModelResourceLocation(type.item, 0, new ModelResourceLocation(new ResourceLocation(IronTanks.MODID, "iron_tank_upgrades"), "variant=" + type.itemName));
-        }
-
-        for (IronTankType type : IronTankType.VALUES) {
-            ModelLoader.setCustomModelResourceLocation(Content.ironTankItemBlock, type.metaValue, new ModelResourceLocation(Content.ironTankItemBlock.getRegistryName(), "stacked=false,variant=" + type.name));
-        }
-
-    }
-
-
 }

--- a/src/main/java/com/indemnity83/irontanks/common/Content.java
+++ b/src/main/java/com/indemnity83/irontanks/common/Content.java
@@ -34,6 +34,10 @@ public final class Content {
             ModelLoader.setCustomModelResourceLocation(type.item, 0, new ModelResourceLocation(new ResourceLocation(IronTanks.MODID, "iron_tank_upgrades"), "variant=" + type.itemName));
         }
 
+        for (IronTankType type : IronTankType.VALUES) {
+            ModelLoader.setCustomModelResourceLocation(Content.ironTankItemBlock, type.metaValue, new ModelResourceLocation(Content.ironTankItemBlock.getRegistryName(), "stacked=false,variant=" + type.name));
+        }
+
     }
 
 


### PR DESCRIPTION
This PR implements the client/server proxy to resolve #39 and makes changes to the block/item rendering. 

There is a known bug in this PR where the BlockItem for a tank renders without a texture when in a player's inventory.