### PR TITLE
chore: bump gradle wrapper from 3.3 to 4.10.3

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.3-all.zip


### PR DESCRIPTION
Probes the real Gradle ceiling for the FG 2.3 toolchain on mc/1.12.2. 4.10.3 is the last Gradle 4.x; Gradle 5 removes APIs ForgeGradle 2 relies on, and Gradle 9 (what dependabot proposed) requires JDK 17 while this builds on JDK 8. Replaces the impossible wrapper->9.5.1 PR.