### PR TITLE
feat: add configuration for Creative Tank breakability settings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,13 @@ updates:
     commit-message:
       prefix: "chore"
       prefix-development: "chore"
+    ignore:
+      # ForgeGradle is pinned to a 2.3 -SNAPSHOT; FG3+ dropped the
+      # 'net.minecraftforge.gradle.forge' plugin id this build uses.
+      - dependency-name: "net.minecraftforge.gradle:ForgeGradle"
+      # FG2 relies on Gradle APIs removed in Gradle 5 (and this builds on JDK8).
+      - dependency-name: "gradle-wrapper"
+        versions: [">=5.0"]
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -27,6 +34,13 @@ updates:
     commit-message:
       prefix: "chore"
       prefix-development: "chore"
+    ignore:
+      # ForgeGradle is pinned to a 2.2 -SNAPSHOT; FG3+ dropped the
+      # 'net.minecraftforge.gradle.forge' plugin id this build uses.
+      - dependency-name: "net.minecraftforge.gradle:ForgeGradle"
+      # FG2 relies on Gradle APIs removed in Gradle 5 (and this builds on JDK8).
+      - dependency-name: "gradle-wrapper"
+        versions: [">=5.0"]
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -45,6 +59,13 @@ updates:
     commit-message:
       prefix: "chore"
       prefix-development: "chore"
+    ignore:
+      # ForgeGradle is pinned to a 1.2 -SNAPSHOT (legacy toolchain; the real
+      # path forward is the RetroFuturaGradle migration).
+      - dependency-name: "net.minecraftforge.gradle:ForgeGradle"
+      # FG 1.2 needs an ancient Gradle; anything >=3 breaks the build.
+      - dependency-name: "gradle-wrapper"
+        versions: [">=3.0"]
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/src/main/java/com/indemnity83/irontanks/common/CommonProxy.java
+++ b/src/main/java/com/indemnity83/irontanks/common/CommonProxy.java
@@ -6,6 +6,7 @@ import com.indemnity83.irontanks.common.blocks.CreativeTankBlock;
 import com.indemnity83.irontanks.common.blocks.StackableTankBlock;
 import com.indemnity83.irontanks.common.blocks.VoidTankBlock;
 import com.indemnity83.irontanks.common.core.Blocks;
+import com.indemnity83.irontanks.common.core.IronTanksConfig;
 import com.indemnity83.irontanks.common.core.Items;
 import com.indemnity83.irontanks.common.items.UpgradeItem;
 import com.indemnity83.irontanks.common.tiles.CreativeTankTile;
@@ -71,6 +72,7 @@ public class CommonProxy {
      * @param event
      */
     public void preInit(FMLPreInitializationEvent event) {
+        IronTanksConfig.load(event.getSuggestedConfigurationFile());
     }
 
     /**

--- a/src/main/java/com/indemnity83/irontanks/common/blocks/CreativeTankBlock.java
+++ b/src/main/java/com/indemnity83/irontanks/common/blocks/CreativeTankBlock.java
@@ -13,8 +13,6 @@ import java.util.List;
 public class CreativeTankBlock extends TankBlock {
     public CreativeTankBlock(String tankName, int tankCapacity) {
         super(tankName, tankCapacity);
-
-        this.setBlockUnbreakable();
     }
 
     @Override

--- a/src/main/java/com/indemnity83/irontanks/common/core/Blocks.java
+++ b/src/main/java/com/indemnity83/irontanks/common/core/Blocks.java
@@ -38,6 +38,10 @@ public class Blocks {
 
     public static void init() {
         obsidianTank.setResistance(6000);
+
+        if (!IronTanksConfig.creativeTankBreakable) {
+            creativeTank.setBlockUnbreakable();
+        }
     }
 
     @SideOnly(Side.CLIENT)

--- a/src/main/java/com/indemnity83/irontanks/common/core/IronTanksConfig.java
+++ b/src/main/java/com/indemnity83/irontanks/common/core/IronTanksConfig.java
@@ -1,0 +1,29 @@
+package com.indemnity83.irontanks.common.core;
+
+import net.minecraftforge.common.config.Configuration;
+
+import java.io.File;
+
+public final class IronTanksConfig {
+    public static boolean creativeTankBreakable = false;
+
+    private IronTanksConfig() {
+    }
+
+    public static void load(File configFile) {
+        Configuration config = new Configuration(configFile);
+
+        creativeTankBreakable = config.getBoolean(
+                "creativeTankBreakable",
+                Configuration.CATEGORY_GENERAL,
+                false,
+                "Allow the Creative Tank to be broken and harvested like any other tank.\n"
+                        + "Leave this false (the default) to keep Creative Tanks unbreakable so they can\n"
+                        + "be used for fixed, admin-built setups on servers and in modpacks."
+        );
+
+        if (config.hasChanged()) {
+            config.save();
+        }
+    }
+}


### PR DESCRIPTION
### Summary
This update introduces a new configuration option that allows players to set whether Creative Tanks can be broken in survival mode. This flexibility enhances gameplay, particularly for players using the tanks in server environments or modpacks, where they might be used as non-destructible fixtures.

### Changes
- **Creative Tank Breakability Settings**: 
  - Added configuration to determine if Creative Tanks can be broken and harvested. 
  - Default setting keeps Creative Tanks unbreakable to support fixed setups.
  
- **Dependency Management**: 
  - Updated GitHub Dependabot configuration to prevent proposing incompatible bumps for Gradle and ForgeGradle, ensuring better build stability.

### Notes
- Players can now modify the Creative Tank breakability setting via the configuration file, allowing for tailored gameplay experiences. 
- Default behavior maintains Creative Tank's invulnerability to ensure they remain useful for specific use cases in modded environments. Make sure to check the configuration if you want to change this behavior.
- Closes #68 