### PR TITLE
chore: block RFG major bumps for mc/1.7.10 in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -60,12 +60,13 @@ updates:
       prefix: "chore"
       prefix-development: "chore"
     ignore:
-      # ForgeGradle is pinned to a 1.2 -SNAPSHOT (legacy toolchain; the real
-      # path forward is the RetroFuturaGradle migration).
-      - dependency-name: "net.minecraftforge.gradle:ForgeGradle"
-      # FG 1.2 needs an ancient Gradle; anything >=3 breaks the build.
+      # Migrated off ForgeGradle 1.2 to RetroFuturaGradle in #90. Pinned to the
+      # RFG 1.4.x line (Gradle 8.x / JDK 17-21); RFG 2.x needs Gradle 9 + JDK 25.
+      - dependency-name: "com.gtnewhorizons.retrofuturagradle*"
+        update-types: ["version-update:semver-major"]
+      # Gradle wrapper must stay on 8.x to match RFG 1.4.x.
       - dependency-name: "gradle-wrapper"
-        versions: [">=3.0"]
+        versions: [">=9.0"]
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
## What

Fixes the `mc/1.7.10` gradle `ignore:` block in the root dependabot config (this default branch is the **only** config Dependabot reads).

## Why

Dependabot opened #93 bumping **RetroFuturaGradle 1.4.9 → 2.0.2** on `mc/1.7.10`, which breaks CI — RFG 2.x requires Gradle 9 + JDK 25, but that branch is intentionally pinned to the RFG 1.4.x line (Gradle 8.x / JDK 17–21).

The `mc/1.7.10` ignore block was stale post-migration:
- It still ignored `net.minecraftforge.gradle:ForgeGradle` — removed in #90 when the branch migrated to RFG.
- It capped `gradle-wrapper` at `>=3.0`, but the wrapper is now Gradle **8.8**.
- It never mentioned RFG, so the major bump slipped through.

Note: an ignore rule was added to `dependabot.yml` *on the `mc/1.7.10` branch* in #90, but Dependabot only reads config from the default branch (`mc/1.12.2`), so it had no effect. This is the fix in the right place.

## Change

- Ignore RFG `version-update:semver-major` bumps.
- Cap `gradle-wrapper` at `<9.0` (must stay on 8.x for RFG 1.4.x).

🤖 Generated with [Claude Code](https://claude.com/claude-code)