### PR TITLE
fix(deps): use buildcraftfactory modid for BuildCraft dependency

### DIFF
--- a/src/main/java/com/indemnity83/irontanks/IronTanks.java
+++ b/src/main/java/com/indemnity83/irontanks/IronTanks.java
@@ -14,7 +14,7 @@ import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
         name = IronTanks.MODNAME,
         version = IronTanks.VERSION,
         acceptedMinecraftVersions = "(gradle_replace_mcversion,)",
-        dependencies = "required-after:forge@(gradle_replace_forgeversion,);required-after:BuildCraft|Factory@(gradle_replace_buildcraftversion,)"
+        dependencies = "required-after:forge@(gradle_replace_forgeversion,);required-after:buildcraftfactory@(gradle_replace_buildcraftversion,)"
 )
 public class IronTanks {
 


### PR DESCRIPTION
## Problem

Launching the client on `mc/1.11.2` fails with an in-game error that the **BuildCraft factory** mod is missing — even though BuildCraft is present on the classpath.

## Root cause

The `@Mod` dependency string used BuildCraft's **legacy modid** `BuildCraft|Factory`:

```java
dependencies = "...;required-after:BuildCraft|Factory@(gradle_replace_buildcraftversion,)"
```

BuildCraft 7.99.x (the 1.11.2-era rewrite pulled in by `buildcraft_version=7.99.7`) split into lowercase per-module modids. Unpacking the 7.99.7 jar's `mcmod.info` confirms the factory module registers as **`buildcraftfactory`**:

```
buildcraftlib, buildcraftcore, buildcraftbuilders, buildcraftenergy,
buildcraftfactory, buildcrafttransport, buildcraftsilicon, buildcraftrobotics
```

Forge searched for a mod with id `BuildCraft|Factory`, found none by that id, and reported the dependency as missing.

## Fix

Change the required modid to `buildcraftfactory`. `buildcraftfactory` transitively requires the rest of BuildCraft, so gating on the one module is sufficient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)