### PR TITLE
chore: anchor mc/26.1 release-please floor to the rewrite commit

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "last-release-sha": "c14d864ad228ac7accb27b6b090d25840027d062",
   "changelog-sections": [
     { "type": "feat", "section": "Added" },
     { "type": "fix", "section": "Fixed" },
@@ -11,8 +12,7 @@
       "component": "mc26.1",
       "release-type": "simple",
       "include-component-in-tag": true,
-      "pull-request-title-pattern": "chore(release): release ${version} for ${component}",
-      "bootstrap-sha": "c14d864ad228ac7accb27b6b090d25840027d062"
+      "pull-request-title-pattern": "chore(release): release ${version} for ${component}"
     }
   }
 }


### PR DESCRIPTION
## Summary

Fixes release-please picking up stale 1.12.2-era commits and proposing the wrong version on the `mc/26.1` line.

## Changes

- Move the release floor to a **top-level** `last-release-sha` (`c14d864`, the commit before #104).
- Drop the per-package `bootstrap-sha`, which was silently ignored (it's a top-level key, and `bootstrap-sha` only applies when the manifest has no entry).

## Notes

`last-release-sha`/`bootstrap-sha` are top-level manifest-config keys — nested under the package they do nothing, so release-please was scanning the full shared history and anchoring on the old `chore(release): graduate 1.12.2 to stable 2.1.0` commit.

With the floor at `c14d864`, release-please now scans only the multiloader rewrite (#104, `feat!`) against the `2.1.0` baseline → next release is **3.0.0**.