### PR TITLE
ci: split Check Code into lint, test, and build stages with Spotless

### DIFF
--- a/.github/actions/setup-build/action.yml
+++ b/.github/actions/setup-build/action.yml
@@ -1,0 +1,22 @@
+name: Setup build
+description: JDK 25 (Temurin) + Gradle with encrypted cache for Iron Tanks CI
+
+# Composite actions can't read the `secrets` context directly, so the caller passes
+# the Gradle cache encryption key in as an input.
+inputs:
+  cache-encryption-key:
+    description: Gradle cache encryption key (pass secrets.GRADLE_ENCRYPTION_KEY)
+    required: false
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
+      with:
+        distribution: temurin
+        java-version: '25'
+
+    - name: Setup Gradle
+      uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
+      with:
+        cache-encryption-key: ${{ inputs.cache-encryption-key }}

--- a/.github/workflows/check-code.yml
+++ b/.github/workflows/check-code.yml
@@ -15,8 +15,9 @@ permissions:
   contents: read
 
 jobs:
-  build:
-    name: build
+  # Format gate: Spotless (palantir-java-format for Java, gson for JSON). Cheap, runs first.
+  lint:
+    name: lint
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
 
@@ -25,16 +26,51 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
-        with:
-          distribution: temurin
-          java-version: '25'
-
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
+      - uses: ./.github/actions/setup-build
         with:
           cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
-      # Builds every module: core (with unit tests) plus the fabric and neoforge loader jars.
-      - name: Build with Gradle
-        run: ./gradlew build --console=plain
+      - name: Check formatting
+        run: ./gradlew spotlessCheck --console=plain
+
+  # Pure-logic unit tests. `core` is the only module with a test source set today.
+  test:
+    name: test
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - uses: ./.github/actions/setup-build
+        with:
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+
+      - name: Run core tests
+        run: ./gradlew :core:test --console=plain
+
+  # Smoke-build each loader jar (compile + assemble). Loaders have no test source set,
+  # so a clean jar is their coverage. Only runs once lint + test pass.
+  build:
+    name: build (${{ matrix.loader }})
+    needs: [lint, test]
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        loader: [fabric, neoforge]
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - uses: ./.github/actions/setup-build
+        with:
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+
+      - name: Build ${{ matrix.loader }} jar
+        run: ./gradlew :${{ matrix.loader }}:jar --console=plain

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,6 +73,8 @@ toolchains, so changes do **not** cherry-pick between them — port by hand. Wit
 ./gradlew :fabric:runClient     # Launch the Fabric dev client
 ./gradlew :neoforge:jar         # Build just the NeoForge mod jar
 ./gradlew :fabric:jar           # Build just the Fabric mod jar
+./gradlew spotlessCheck         # Lint: verify formatting (the CI gate)
+./gradlew spotlessApply         # Auto-fix formatting (Java + JSON)
 ```
 
 **Requirements:** **JDK 25** and Gradle 9.x (via the wrapper). Versions live in `gradle.properties`
@@ -195,11 +197,14 @@ so the files reach both the mod jar and the dev resource root — no per-loader 
 
 ## Code Style
 
-- Formatting is governed by **`.editorconfig`** (no Spotless / auto-formatter):
-  UTF-8, LF, final newline, trim trailing whitespace; Java: 4-space indent.
+- Formatting is enforced by **Spotless** (configured once in the root `build.gradle`):
+  **palantir-java-format** for Java (4-space indent), **gson** for JSON resources. Base whitespace
+  rules (UTF-8, LF, final newline, trim trailing whitespace) still live in **`.editorconfig`**.
+  Run `./gradlew spotlessApply` to fix and `./gradlew spotlessCheck` to verify.
 - Single-line `if`/`for` allowed; prefer braces for multi-line bodies; keep nesting ≤ 3 levels.
-- **CI** (`check-code.yml`) runs `./gradlew build` (JDK 25) on PRs into `mc/**` — this builds every
-  module and runs `core`'s tests. There is no separate format/lint gate beyond the PR-title check.
+- **CI** (`check-code.yml`, JDK 25, on PRs into `mc/**`) splits into three jobs: `lint`
+  (`spotlessCheck`), `test` (`:core:test`), and a `build` matrix that smoke-builds each loader jar
+  once lint + test pass. Formatting is now a hard CI gate, not just the PR-title check.
 
 ## Commit Messages
 
@@ -242,7 +247,9 @@ Internal types kept out of the changelog: `refactor`, `test`, `build`, `ci`, `ch
 GitHub Actions in `.github/workflows/`:
 
 - **`check-pr.yml`** — validates the PR title (no-scope conventional commit, lowercase subject).
-- **`check-code.yml`** — `./gradlew build` (JDK 25) on push/PR into `mc/**` (builds all modules + tests).
+- **`check-code.yml`** — JDK 25 on push/PR into `mc/**`; three jobs: `lint` (`spotlessCheck`), `test`
+  (`:core:test`), and a `build` matrix (`[fabric, neoforge]`) that smoke-builds each loader jar and
+  runs only after lint + test pass. JDK/Gradle setup is shared via the `setup-build` composite action.
 - **`prepare-release.yml`** — runs release-please on pushes to `mc/*`.
 - **`build-release.yml`** — on a published release (or manual `workflow_dispatch`), builds **both** loader
   jars (matrix `[fabric, neoforge]`) and, when publishing, uploads to Modrinth/CurseForge via `mc-publish`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,6 +73,8 @@ toolchains, so changes do **not** cherry-pick between them — port by hand. Wit
 ./gradlew :fabric:runClient     # Launch the Fabric dev client
 ./gradlew :neoforge:jar         # Build just the NeoForge mod jar
 ./gradlew :fabric:jar           # Build just the Fabric mod jar
+./gradlew spotlessCheck         # Lint: verify formatting (the CI gate)
+./gradlew spotlessApply         # Auto-fix formatting (Java + JSON)
 ```
 
 **Requirements:** **JDK 25** and Gradle 9.x (via the wrapper). Versions live in `gradle.properties`
@@ -195,11 +197,14 @@ so the files reach both the mod jar and the dev resource root — no per-loader 
 
 ## Code Style
 
-- Formatting is governed by **`.editorconfig`** (no Spotless / auto-formatter):
-  UTF-8, LF, final newline, trim trailing whitespace; Java: 4-space indent.
+- Formatting is enforced by **Spotless** (configured once in the root `build.gradle`):
+  **palantir-java-format** for Java (4-space indent), **gson** for JSON resources. Base whitespace
+  rules (UTF-8, LF, final newline, trim trailing whitespace) still live in **`.editorconfig`**.
+  Run `./gradlew spotlessApply` to fix and `./gradlew spotlessCheck` to verify.
 - Single-line `if`/`for` allowed; prefer braces for multi-line bodies; keep nesting ≤ 3 levels.
-- **CI** (`check-code.yml`) runs `./gradlew build` (JDK 25) on PRs into `mc/**` — this builds every
-  module and runs `core`'s tests. There is no separate format/lint gate beyond the PR-title check.
+- **CI** (`check-code.yml`, JDK 25, on PRs into `mc/**`) splits into three jobs: `lint`
+  (`spotlessCheck`), `test` (`:core:test`), and a `build` matrix that smoke-builds each loader jar
+  once lint + test pass. Formatting is now a hard CI gate, not just the PR-title check.
 
 ## Commit Messages
 
@@ -242,7 +247,9 @@ Internal types kept out of the changelog: `refactor`, `test`, `build`, `ci`, `ch
 GitHub Actions in `.github/workflows/`:
 
 - **`check-pr.yml`** — validates the PR title (no-scope conventional commit, lowercase subject).
-- **`check-code.yml`** — `./gradlew build` (JDK 25) on push/PR into `mc/**` (builds all modules + tests).
+- **`check-code.yml`** — JDK 25 on push/PR into `mc/**`; three jobs: `lint` (`spotlessCheck`), `test`
+  (`:core:test`), and a `build` matrix (`[fabric, neoforge]`) that smoke-builds each loader jar and
+  runs only after lint + test pass. JDK/Gradle setup is shared via the `setup-build` composite action.
 - **`prepare-release.yml`** — runs release-please on pushes to `mc/*`.
 - **`build-release.yml`** — on a published release (or manual `workflow_dispatch`), builds **both** loader
   jars (matrix `[fabric, neoforge]`) and, when publishing, uploads to Modrinth/CurseForge via `mc-publish`

--- a/build.gradle
+++ b/build.gradle
@@ -4,8 +4,34 @@
 // fluid-stacking math, void rate and upgrade rules; the `fabric` and `neoforge` modules each provide
 // their own thin Minecraft glue and depend on `core`. See the plan and CLAUDE.md for the rationale.
 
+plugins {
+    id 'com.diffplug.spotless'
+}
+
 allprojects {
     group = rootProject.maven_group
     // Version is injected by release CI via MOD_VERSION; local/dev builds get a static marker.
     version = System.getenv("MOD_VERSION") ?: "dev-local"
+}
+
+// Spotless resolves its formatter (palantir-java-format) from the root project's repositories.
+repositories {
+    mavenCentral()
+}
+
+// Formatting is enforced once at the root across all modules (no per-subproject duplication):
+// `./gradlew spotlessApply` to fix, `./gradlew spotlessCheck` is the CI lint gate.
+spotless {
+    java {
+        target 'core/src/**/*.java', 'fabric/src/**/*.java', 'neoforge/src/**/*.java'
+        palantirJavaFormat("${palantir_version}")
+        removeUnusedImports()
+        // palantir-java-format emits 4-space indentation and trims/ends files to match .editorconfig.
+    }
+    json {
+        target 'resources/**/*.json',
+               'fabric/src/main/resources/**/*.json',
+               'neoforge/src/main/resources/**/*.json'
+        gson().indentWithSpaces(2)
+    }
 }

--- a/core/src/main/java/com/indemnity83/irontanks/core/FluidColumn.java
+++ b/core/src/main/java/com/indemnity83/irontanks/core/FluidColumn.java
@@ -14,8 +14,7 @@ package com.indemnity83.irontanks.core;
  */
 public final class FluidColumn {
 
-    private FluidColumn() {
-    }
+    private FluidColumn() {}
 
     /** Total capacity of the column (sum of per-tank capacities). */
     public static long totalCapacity(long[] capacities) {

--- a/core/src/main/java/com/indemnity83/irontanks/core/VoidTank.java
+++ b/core/src/main/java/com/indemnity83/irontanks/core/VoidTank.java
@@ -10,8 +10,7 @@ package com.indemnity83.irontanks.core;
  */
 public final class VoidTank {
 
-    private VoidTank() {
-    }
+    private VoidTank() {}
 
     /** Maximum millibuckets destroyed per tick. */
     public static final long RATE = 20;

--- a/core/src/test/java/com/indemnity83/irontanks/core/FluidColumnTest.java
+++ b/core/src/test/java/com/indemnity83/irontanks/core/FluidColumnTest.java
@@ -44,26 +44,24 @@ class FluidColumnTest {
 
     @Test
     void settleRejectsNegativeOrOverfull() {
-        assertThatThrownBy(() -> FluidColumn.settle(COLUMN, -1, false))
-                .isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> FluidColumn.settle(COLUMN, 3001, false))
-                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> FluidColumn.settle(COLUMN, -1, false)).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> FluidColumn.settle(COLUMN, 3001, false)).isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
     void fillableCapsAtRemainingRoom() {
-        assertThat(FluidColumn.fillable(3000, 1000, 500)).isEqualTo(500);   // fits
-        assertThat(FluidColumn.fillable(3000, 2800, 500)).isEqualTo(200);   // clipped to room
-        assertThat(FluidColumn.fillable(3000, 3000, 500)).isZero();         // full
-        assertThat(FluidColumn.fillable(3000, 1000, 0)).isZero();           // nothing requested
-        assertThat(FluidColumn.fillable(3000, 1000, -5)).isZero();          // negative request
+        assertThat(FluidColumn.fillable(3000, 1000, 500)).isEqualTo(500); // fits
+        assertThat(FluidColumn.fillable(3000, 2800, 500)).isEqualTo(200); // clipped to room
+        assertThat(FluidColumn.fillable(3000, 3000, 500)).isZero(); // full
+        assertThat(FluidColumn.fillable(3000, 1000, 0)).isZero(); // nothing requested
+        assertThat(FluidColumn.fillable(3000, 1000, -5)).isZero(); // negative request
     }
 
     @Test
     void drainableCapsAtCurrentContents() {
-        assertThat(FluidColumn.drainable(1500, 500)).isEqualTo(500);   // fits
-        assertThat(FluidColumn.drainable(300, 500)).isEqualTo(300);    // clipped to contents
-        assertThat(FluidColumn.drainable(0, 500)).isZero();            // empty
-        assertThat(FluidColumn.drainable(1500, 0)).isZero();           // nothing requested
+        assertThat(FluidColumn.drainable(1500, 500)).isEqualTo(500); // fits
+        assertThat(FluidColumn.drainable(300, 500)).isEqualTo(300); // clipped to contents
+        assertThat(FluidColumn.drainable(0, 500)).isZero(); // empty
+        assertThat(FluidColumn.drainable(1500, 0)).isZero(); // nothing requested
     }
 }

--- a/core/src/test/java/com/indemnity83/irontanks/core/VoidTankTest.java
+++ b/core/src/test/java/com/indemnity83/irontanks/core/VoidTankTest.java
@@ -10,7 +10,7 @@ class VoidTankTest {
     void destroysAtMostTheRatePerTick() {
         assertThat(VoidTank.RATE).isEqualTo(20);
         assertThat(VoidTank.drainPerTick(1000)).isEqualTo(20); // plenty held -> full rate
-        assertThat(VoidTank.drainPerTick(5)).isEqualTo(5);     // less than rate -> only what's there
-        assertThat(VoidTank.drainPerTick(0)).isZero();         // empty -> nothing
+        assertThat(VoidTank.drainPerTick(5)).isEqualTo(5); // less than rate -> only what's there
+        assertThat(VoidTank.drainPerTick(0)).isZero(); // empty -> nothing
     }
 }

--- a/fabric/src/client/java/com/indemnity83/irontanks/fabric/client/TankBlockEntityRenderer.java
+++ b/fabric/src/client/java/com/indemnity83/irontanks/fabric/client/TankBlockEntityRenderer.java
@@ -33,8 +33,7 @@ public class TankBlockEntityRenderer implements BlockEntityRenderer<TankBlockEnt
     private static final float FLOOR = 0.0F;
     private static final float FULL_SURFACE = 15.5F / 16F;
 
-    public TankBlockEntityRenderer(BlockEntityRendererProvider.Context context) {
-    }
+    public TankBlockEntityRenderer(BlockEntityRendererProvider.Context context) {}
 
     @Override
     public TankRenderState createRenderState() {
@@ -63,7 +62,10 @@ public class TankBlockEntityRenderer implements BlockEntityRenderer<TankBlockEnt
         if (state.hasFluid) {
             FluidState fluidState = tank.fluidVariant().getFluid().defaultFluidState();
             // 26.1 resolves fluid sprites/tint through the baked fluid-model set.
-            FluidModel model = Minecraft.getInstance().getModelManager().getFluidStateModelSet().get(fluidState);
+            FluidModel model = Minecraft.getInstance()
+                    .getModelManager()
+                    .getFluidStateModelSet()
+                    .get(fluidState);
             state.sprite = model.stillMaterial().sprite();
             // Biome-tinted fluids (water) need world context via colorInWorld; tintSource is null for
             // untinted fluids (lava) — fall back to no tint (white) in both the null and non-client cases.
@@ -91,35 +93,64 @@ public class TankBlockEntityRenderer implements BlockEntityRenderer<TankBlockEnt
         float wallTop = state.renderTop ? surface : 1.0F;
         boolean renderTop = state.renderTop;
 
-        queue.submitCustomGeometry(pose, RenderTypes.translucentMovingBlock(),
+        queue.submitCustomGeometry(
+                pose,
+                RenderTypes.translucentMovingBlock(),
                 (entry, buffer) -> renderFluid(entry, buffer, sprite, color, light, surface, wallTop, renderTop));
     }
 
     private static void renderFluid(
-            PoseStack.Pose entry, VertexConsumer buffer, TextureAtlasSprite sprite, int color, int light,
-            float surface, float wallTop, boolean renderTop) {
+            PoseStack.Pose entry,
+            VertexConsumer buffer,
+            TextureAtlasSprite sprite,
+            int color,
+            int light,
+            float surface,
+            float wallTop,
+            boolean renderTop) {
         if (renderTop) {
             // Top surface (normal +Y), seen from above.
-            quad(entry, buffer, sprite, color, light, 0, 1, 0,
-                    MIN, surface, MIN, MIN, surface, MAX, MAX, surface, MAX, MAX, surface, MIN);
+            quad(
+                    entry, buffer, sprite, color, light, 0, 1, 0, MIN, surface, MIN, MIN, surface, MAX, MAX, surface,
+                    MAX, MAX, surface, MIN);
         }
         // North (-Z) and South (+Z) walls.
-        quad(entry, buffer, sprite, color, light, 0, 0, -1,
-                MIN, FLOOR, MIN, MAX, FLOOR, MIN, MAX, wallTop, MIN, MIN, wallTop, MIN);
-        quad(entry, buffer, sprite, color, light, 0, 0, 1,
-                MAX, FLOOR, MAX, MIN, FLOOR, MAX, MIN, wallTop, MAX, MAX, wallTop, MAX);
+        quad(
+                entry, buffer, sprite, color, light, 0, 0, -1, MIN, FLOOR, MIN, MAX, FLOOR, MIN, MAX, wallTop, MIN, MIN,
+                wallTop, MIN);
+        quad(
+                entry, buffer, sprite, color, light, 0, 0, 1, MAX, FLOOR, MAX, MIN, FLOOR, MAX, MIN, wallTop, MAX, MAX,
+                wallTop, MAX);
         // West (-X) and East (+X) walls.
-        quad(entry, buffer, sprite, color, light, -1, 0, 0,
-                MIN, FLOOR, MAX, MIN, FLOOR, MIN, MIN, wallTop, MIN, MIN, wallTop, MAX);
-        quad(entry, buffer, sprite, color, light, 1, 0, 0,
-                MAX, FLOOR, MIN, MAX, FLOOR, MAX, MAX, wallTop, MAX, MAX, wallTop, MIN);
+        quad(
+                entry, buffer, sprite, color, light, -1, 0, 0, MIN, FLOOR, MAX, MIN, FLOOR, MIN, MIN, wallTop, MIN, MIN,
+                wallTop, MAX);
+        quad(
+                entry, buffer, sprite, color, light, 1, 0, 0, MAX, FLOOR, MIN, MAX, FLOOR, MAX, MAX, wallTop, MAX, MAX,
+                wallTop, MIN);
     }
 
     private static void quad(
-            PoseStack.Pose entry, VertexConsumer buffer, TextureAtlasSprite sprite, int color, int light,
-            float nx, float ny, float nz,
-            float x1, float y1, float z1, float x2, float y2, float z2,
-            float x3, float y3, float z3, float x4, float y4, float z4) {
+            PoseStack.Pose entry,
+            VertexConsumer buffer,
+            TextureAtlasSprite sprite,
+            int color,
+            int light,
+            float nx,
+            float ny,
+            float nz,
+            float x1,
+            float y1,
+            float z1,
+            float x2,
+            float y2,
+            float z2,
+            float x3,
+            float y3,
+            float z3,
+            float x4,
+            float y4,
+            float z4) {
         float u0 = sprite.getU0();
         float u1 = sprite.getU1();
         float v0 = sprite.getV0();
@@ -137,8 +168,18 @@ public class TankBlockEntityRenderer implements BlockEntityRenderer<TankBlockEnt
     }
 
     private static void vertex(
-            PoseStack.Pose entry, VertexConsumer buffer, int color, int light,
-            float nx, float ny, float nz, float x, float y, float z, float u, float v) {
+            PoseStack.Pose entry,
+            VertexConsumer buffer,
+            int color,
+            int light,
+            float nx,
+            float ny,
+            float nz,
+            float x,
+            float y,
+            float z,
+            float u,
+            float v) {
         buffer.addVertex(entry, x, y, z)
                 .setColor(color)
                 .setUv(u, v)

--- a/fabric/src/client/java/com/indemnity83/irontanks/fabric/client/TankRenderState.java
+++ b/fabric/src/client/java/com/indemnity83/irontanks/fabric/client/TankRenderState.java
@@ -15,7 +15,9 @@ public class TankRenderState extends BlockEntityRenderState {
     public boolean full;
     /** Draw the fluid's top surface here; false when connected fluid continues above, so columns merge. */
     public boolean renderTop;
+
     @Nullable
     public TextureAtlasSprite sprite;
+
     public int tintColor = 0xFFFFFFFF;
 }

--- a/fabric/src/main/java/com/indemnity83/irontanks/fabric/content/IronTanksContent.java
+++ b/fabric/src/main/java/com/indemnity83/irontanks/fabric/content/IronTanksContent.java
@@ -31,8 +31,7 @@ import net.minecraft.world.level.block.state.BlockBehaviour;
  */
 public final class IronTanksContent {
 
-    private IronTanksContent() {
-    }
+    private IronTanksContent() {}
 
     public static final Map<TankTier, Block> TANK_BLOCKS = new EnumMap<>(TankTier.class);
     public static BlockEntityType<TankBlockEntity> TANK_BLOCK_ENTITY;
@@ -50,7 +49,8 @@ public final class IronTanksContent {
         TANK_BLOCK_ENTITY = Registry.register(
                 BuiltInRegistries.BLOCK_ENTITY_TYPE,
                 id("tank"),
-                FabricBlockEntityTypeBuilder.create(TankBlockEntity::new, TANK_BLOCKS.values().toArray(new Block[0]))
+                FabricBlockEntityTypeBuilder.create(
+                                TankBlockEntity::new, TANK_BLOCKS.values().toArray(new Block[0]))
                         .build());
 
         registerCreativeTab();
@@ -72,7 +72,8 @@ public final class IronTanksContent {
         TANK_BLOCKS.put(tier, block);
 
         ResourceKey<Item> itemKey = ResourceKey.create(Registries.ITEM, id(name));
-        BlockItem item = new TankBlockItem(block, new Item.Properties().setId(itemKey).useBlockDescriptionPrefix());
+        BlockItem item =
+                new TankBlockItem(block, new Item.Properties().setId(itemKey).useBlockDescriptionPrefix());
         Registry.register(BuiltInRegistries.ITEM, itemKey, item);
         TAB_ITEMS.add(item);
     }

--- a/fabric/src/main/java/com/indemnity83/irontanks/fabric/content/TankBlock.java
+++ b/fabric/src/main/java/com/indemnity83/irontanks/fabric/content/TankBlock.java
@@ -34,9 +34,12 @@ import org.jetbrains.annotations.Nullable;
 public class TankBlock extends BaseEntityBlock {
 
     public static final MapCodec<TankBlock> CODEC = RecordCodecBuilder.mapCodec(instance -> instance.group(
-            Codec.STRING.xmap(TankTier::valueOf, TankTier::name).fieldOf("tier").forGetter(TankBlock::tier),
-            propertiesCodec()
-    ).apply(instance, TankBlock::new));
+                    Codec.STRING
+                            .xmap(TankTier::valueOf, TankTier::name)
+                            .fieldOf("tier")
+                            .forGetter(TankBlock::tier),
+                    propertiesCodec())
+            .apply(instance, TankBlock::new));
 
     /** True when a connecting tank sits directly below, so the seamless {@code side_stacked} texture is used. */
     public static final BooleanProperty JOINED_BELOW = BooleanProperty.create("joined_below");
@@ -66,7 +69,12 @@ public class TankBlock extends BaseEntityBlock {
     /** Right-click with a bucket (or any fluid container) to fill the tank or fill the container from it. */
     @Override
     protected InteractionResult useItemOn(
-            ItemStack stack, BlockState state, Level level, BlockPos pos, Player player, InteractionHand hand,
+            ItemStack stack,
+            BlockState state,
+            Level level,
+            BlockPos pos,
+            Player player,
+            InteractionHand hand,
             BlockHitResult hit) {
         if (level.getBlockEntity(pos) instanceof TankBlockEntity tank
                 && FluidStorageUtil.interactWithFluidStorage(new TankFluidStorage(tank), player, hand)) {
@@ -78,14 +86,21 @@ public class TankBlock extends BaseEntityBlock {
     @Nullable
     @Override
     public BlockState getStateForPlacement(BlockPlaceContext context) {
-        BlockState below = context.getLevel().getBlockState(context.getClickedPos().below());
+        BlockState below =
+                context.getLevel().getBlockState(context.getClickedPos().below());
         return defaultBlockState().setValue(JOINED_BELOW, joinsWithBelow(below));
     }
 
     @Override
     protected BlockState updateShape(
-            BlockState state, LevelReader level, ScheduledTickAccess scheduledTickAccess, BlockPos pos,
-            Direction direction, BlockPos neighborPos, BlockState neighborState, RandomSource random) {
+            BlockState state,
+            LevelReader level,
+            ScheduledTickAccess scheduledTickAccess,
+            BlockPos pos,
+            Direction direction,
+            BlockPos neighborPos,
+            BlockState neighborState,
+            RandomSource random) {
         if (direction == Direction.DOWN) {
             state = state.setValue(JOINED_BELOW, joinsWithBelow(neighborState));
         }
@@ -119,8 +134,10 @@ public class TankBlock extends BaseEntityBlock {
 
     @Nullable
     @Override
-    public <T extends BlockEntity> BlockEntityTicker<T> getTicker(Level level, BlockState state, BlockEntityType<T> type) {
-        return level.isClientSide() ? null
+    public <T extends BlockEntity> BlockEntityTicker<T> getTicker(
+            Level level, BlockState state, BlockEntityType<T> type) {
+        return level.isClientSide()
+                ? null
                 : createTickerHelper(type, IronTanksContent.TANK_BLOCK_ENTITY, TankBlockEntity::serverTick);
     }
 }

--- a/fabric/src/main/java/com/indemnity83/irontanks/fabric/content/TankBlockItem.java
+++ b/fabric/src/main/java/com/indemnity83/irontanks/fabric/content/TankBlockItem.java
@@ -19,15 +19,21 @@ public class TankBlockItem extends BlockItem {
 
     @Override
     public void appendHoverText(
-            ItemStack stack, Item.TooltipContext context, TooltipDisplay tooltipDisplay,
-            Consumer<Component> consumer, TooltipFlag flag) {
+            ItemStack stack,
+            Item.TooltipContext context,
+            TooltipDisplay tooltipDisplay,
+            Consumer<Component> consumer,
+            TooltipFlag flag) {
         super.appendHoverText(stack, context, tooltipDisplay, consumer, flag);
         TankTier tier = ((TankBlock) getBlock()).tier();
-        consumer.accept(Component.translatable("irontanks.tooltip.capacity", tier.buckets()).withStyle(ChatFormatting.GRAY));
+        consumer.accept(Component.translatable("irontanks.tooltip.capacity", tier.buckets())
+                .withStyle(ChatFormatting.GRAY));
         if (tier == TankTier.VOID) {
-            consumer.accept(Component.translatable("irontanks.tooltip.void_tank").withStyle(ChatFormatting.GRAY));
+            consumer.accept(
+                    Component.translatable("irontanks.tooltip.void_tank").withStyle(ChatFormatting.GRAY));
         } else if (tier == TankTier.CREATIVE) {
-            consumer.accept(Component.translatable("irontanks.tooltip.creative_tank").withStyle(ChatFormatting.GRAY));
+            consumer.accept(
+                    Component.translatable("irontanks.tooltip.creative_tank").withStyle(ChatFormatting.GRAY));
         }
     }
 }

--- a/fabric/src/main/java/com/indemnity83/irontanks/fabric/content/TankFluidStorage.java
+++ b/fabric/src/main/java/com/indemnity83/irontanks/fabric/content/TankFluidStorage.java
@@ -28,11 +28,9 @@ public final class TankFluidStorage extends SnapshotParticipant<TankFluidStorage
     private static final long DROPLETS_PER_MB = FluidConstants.BUCKET / TankTier.BUCKET_VOLUME;
 
     /** A tank and its contents at transaction start, restored on abort. */
-    public record Slot(TankBlockEntity tank, FluidVariant fluid, long amount) {
-    }
+    public record Slot(TankBlockEntity tank, FluidVariant fluid, long amount) {}
 
-    public record Snapshot(List<Slot> slots) {
-    }
+    public record Snapshot(List<Slot> slots) {}
 
     private final TankBlockEntity origin;
 

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -4,7 +4,9 @@
   "version": "${version}",
   "name": "Iron Tanks",
   "description": "Tiered-capacity and special-purpose fluid tanks.",
-  "authors": ["Kyle Klaus (@indemnity83)"],
+  "authors": [
+    "Kyle Klaus (@indemnity83)"
+  ],
   "contact": {
     "homepage": "https://github.com/Indemnity83/irontanks",
     "issues": "https://github.com/Indemnity83/irontanks/issues",
@@ -13,8 +15,12 @@
   "license": "MIT",
   "environment": "*",
   "entrypoints": {
-    "main": ["com.indemnity83.irontanks.fabric.IronTanksFabric"],
-    "client": ["com.indemnity83.irontanks.fabric.client.IronTanksFabricClient"]
+    "main": [
+      "com.indemnity83.irontanks.fabric.IronTanksFabric"
+    ],
+    "client": [
+      "com.indemnity83.irontanks.fabric.client.IronTanksFabricClient"
+    ]
   },
   "depends": {
     "fabricloader": ">=${fabric_loader_version}",

--- a/gradle.properties
+++ b/gradle.properties
@@ -32,3 +32,7 @@ moddev_version=2.0.141
 # Test Dependencies
 junit_version=5.11.0
 assertj_version=3.26.0
+
+# Code formatting (Spotless: palantir-java-format for Java, gson for JSON)
+spotless_version=8.6.0
+palantir_version=2.91.0

--- a/neoforge/src/main/java/com/indemnity83/irontanks/neoforge/IronTanksCapabilities.java
+++ b/neoforge/src/main/java/com/indemnity83/irontanks/neoforge/IronTanksCapabilities.java
@@ -12,8 +12,7 @@ import net.neoforged.neoforge.capabilities.RegisterCapabilitiesEvent;
  */
 public final class IronTanksCapabilities {
 
-    private IronTanksCapabilities() {
-    }
+    private IronTanksCapabilities() {}
 
     public static void register(IEventBus modBus) {
         modBus.addListener(IronTanksCapabilities::registerCapabilities);

--- a/neoforge/src/main/java/com/indemnity83/irontanks/neoforge/client/IronTanksClient.java
+++ b/neoforge/src/main/java/com/indemnity83/irontanks/neoforge/client/IronTanksClient.java
@@ -10,8 +10,7 @@ import net.neoforged.neoforge.client.event.EntityRenderersEvent;
  */
 public final class IronTanksClient {
 
-    private IronTanksClient() {
-    }
+    private IronTanksClient() {}
 
     public static void register(IEventBus modBus) {
         modBus.addListener(IronTanksClient::registerRenderers);

--- a/neoforge/src/main/java/com/indemnity83/irontanks/neoforge/client/TankBlockEntityRenderer.java
+++ b/neoforge/src/main/java/com/indemnity83/irontanks/neoforge/client/TankBlockEntityRenderer.java
@@ -33,8 +33,7 @@ public class TankBlockEntityRenderer implements BlockEntityRenderer<TankBlockEnt
     private static final float FLOOR = 0.0F;
     private static final float FULL_SURFACE = 15.5F / 16F;
 
-    public TankBlockEntityRenderer(BlockEntityRendererProvider.Context context) {
-    }
+    public TankBlockEntityRenderer(BlockEntityRendererProvider.Context context) {}
 
     @Override
     public TankRenderState createRenderState() {
@@ -63,7 +62,10 @@ public class TankBlockEntityRenderer implements BlockEntityRenderer<TankBlockEnt
         if (state.hasFluid) {
             FluidState fluidState = tank.fluidResource().value().defaultFluidState();
             // 26.1 resolves fluid sprites/tint through the baked fluid-model set.
-            FluidModel model = Minecraft.getInstance().getModelManager().getFluidStateModelSet().get(fluidState);
+            FluidModel model = Minecraft.getInstance()
+                    .getModelManager()
+                    .getFluidStateModelSet()
+                    .get(fluidState);
             state.sprite = model.stillMaterial().sprite();
             // Biome-tinted fluids (water) need world context via colorInWorld; tintSource is null for
             // untinted fluids (lava) — fall back to no tint (white) in both the null and non-client cases.
@@ -91,35 +93,64 @@ public class TankBlockEntityRenderer implements BlockEntityRenderer<TankBlockEnt
         float wallTop = state.renderTop ? surface : 1.0F;
         boolean renderTop = state.renderTop;
 
-        queue.submitCustomGeometry(pose, RenderTypes.translucentMovingBlock(),
+        queue.submitCustomGeometry(
+                pose,
+                RenderTypes.translucentMovingBlock(),
                 (entry, buffer) -> renderFluid(entry, buffer, sprite, color, light, surface, wallTop, renderTop));
     }
 
     private static void renderFluid(
-            PoseStack.Pose entry, VertexConsumer buffer, TextureAtlasSprite sprite, int color, int light,
-            float surface, float wallTop, boolean renderTop) {
+            PoseStack.Pose entry,
+            VertexConsumer buffer,
+            TextureAtlasSprite sprite,
+            int color,
+            int light,
+            float surface,
+            float wallTop,
+            boolean renderTop) {
         if (renderTop) {
             // Top surface (normal +Y), seen from above.
-            quad(entry, buffer, sprite, color, light, 0, 1, 0,
-                    MIN, surface, MIN, MIN, surface, MAX, MAX, surface, MAX, MAX, surface, MIN);
+            quad(
+                    entry, buffer, sprite, color, light, 0, 1, 0, MIN, surface, MIN, MIN, surface, MAX, MAX, surface,
+                    MAX, MAX, surface, MIN);
         }
         // North (-Z) and South (+Z) walls.
-        quad(entry, buffer, sprite, color, light, 0, 0, -1,
-                MIN, FLOOR, MIN, MAX, FLOOR, MIN, MAX, wallTop, MIN, MIN, wallTop, MIN);
-        quad(entry, buffer, sprite, color, light, 0, 0, 1,
-                MAX, FLOOR, MAX, MIN, FLOOR, MAX, MIN, wallTop, MAX, MAX, wallTop, MAX);
+        quad(
+                entry, buffer, sprite, color, light, 0, 0, -1, MIN, FLOOR, MIN, MAX, FLOOR, MIN, MAX, wallTop, MIN, MIN,
+                wallTop, MIN);
+        quad(
+                entry, buffer, sprite, color, light, 0, 0, 1, MAX, FLOOR, MAX, MIN, FLOOR, MAX, MIN, wallTop, MAX, MAX,
+                wallTop, MAX);
         // West (-X) and East (+X) walls.
-        quad(entry, buffer, sprite, color, light, -1, 0, 0,
-                MIN, FLOOR, MAX, MIN, FLOOR, MIN, MIN, wallTop, MIN, MIN, wallTop, MAX);
-        quad(entry, buffer, sprite, color, light, 1, 0, 0,
-                MAX, FLOOR, MIN, MAX, FLOOR, MAX, MAX, wallTop, MAX, MAX, wallTop, MIN);
+        quad(
+                entry, buffer, sprite, color, light, -1, 0, 0, MIN, FLOOR, MAX, MIN, FLOOR, MIN, MIN, wallTop, MIN, MIN,
+                wallTop, MAX);
+        quad(
+                entry, buffer, sprite, color, light, 1, 0, 0, MAX, FLOOR, MIN, MAX, FLOOR, MAX, MAX, wallTop, MAX, MAX,
+                wallTop, MIN);
     }
 
     private static void quad(
-            PoseStack.Pose entry, VertexConsumer buffer, TextureAtlasSprite sprite, int color, int light,
-            float nx, float ny, float nz,
-            float x1, float y1, float z1, float x2, float y2, float z2,
-            float x3, float y3, float z3, float x4, float y4, float z4) {
+            PoseStack.Pose entry,
+            VertexConsumer buffer,
+            TextureAtlasSprite sprite,
+            int color,
+            int light,
+            float nx,
+            float ny,
+            float nz,
+            float x1,
+            float y1,
+            float z1,
+            float x2,
+            float y2,
+            float z2,
+            float x3,
+            float y3,
+            float z3,
+            float x4,
+            float y4,
+            float z4) {
         float u0 = sprite.getU0();
         float u1 = sprite.getU1();
         float v0 = sprite.getV0();
@@ -137,8 +168,18 @@ public class TankBlockEntityRenderer implements BlockEntityRenderer<TankBlockEnt
     }
 
     private static void vertex(
-            PoseStack.Pose entry, VertexConsumer buffer, int color, int light,
-            float nx, float ny, float nz, float x, float y, float z, float u, float v) {
+            PoseStack.Pose entry,
+            VertexConsumer buffer,
+            int color,
+            int light,
+            float nx,
+            float ny,
+            float nz,
+            float x,
+            float y,
+            float z,
+            float u,
+            float v) {
         buffer.addVertex(entry, x, y, z)
                 .setColor(color)
                 .setUv(u, v)

--- a/neoforge/src/main/java/com/indemnity83/irontanks/neoforge/client/TankRenderState.java
+++ b/neoforge/src/main/java/com/indemnity83/irontanks/neoforge/client/TankRenderState.java
@@ -15,7 +15,9 @@ public class TankRenderState extends BlockEntityRenderState {
     public boolean full;
     /** Draw the fluid's top surface here; false when connected fluid continues above, so columns merge. */
     public boolean renderTop;
+
     @Nullable
     public TextureAtlasSprite sprite;
+
     public int tintColor = 0xFFFFFFFF;
 }

--- a/neoforge/src/main/java/com/indemnity83/irontanks/neoforge/content/IronTanksContent.java
+++ b/neoforge/src/main/java/com/indemnity83/irontanks/neoforge/content/IronTanksContent.java
@@ -33,8 +33,7 @@ import net.minecraft.world.level.block.state.BlockBehaviour;
  */
 public final class IronTanksContent {
 
-    private IronTanksContent() {
-    }
+    private IronTanksContent() {}
 
     public static final Map<TankTier, Block> TANK_BLOCKS = new EnumMap<>(TankTier.class);
     public static BlockEntityType<TankBlockEntity> TANK_BLOCK_ENTITY;
@@ -73,7 +72,8 @@ public final class IronTanksContent {
         TANK_BLOCKS.put(tier, block);
 
         ResourceKey<Item> itemKey = ResourceKey.create(Registries.ITEM, id(name));
-        BlockItem item = new TankBlockItem(block, new Item.Properties().setId(itemKey).useBlockDescriptionPrefix());
+        BlockItem item =
+                new TankBlockItem(block, new Item.Properties().setId(itemKey).useBlockDescriptionPrefix());
         Registry.register(BuiltInRegistries.ITEM, itemKey, item);
         TAB_ITEMS.add(item);
     }

--- a/neoforge/src/main/java/com/indemnity83/irontanks/neoforge/content/TankBlock.java
+++ b/neoforge/src/main/java/com/indemnity83/irontanks/neoforge/content/TankBlock.java
@@ -13,8 +13,6 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.context.BlockPlaceContext;
 import net.minecraft.world.level.Level;
-import net.minecraft.world.phys.BlockHitResult;
-import net.neoforged.neoforge.transfer.fluid.FluidUtil;
 import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.ScheduledTickAccess;
 import net.minecraft.world.level.block.BaseEntityBlock;
@@ -25,6 +23,8 @@ import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.StateDefinition;
 import net.minecraft.world.level.block.state.properties.BooleanProperty;
+import net.minecraft.world.phys.BlockHitResult;
+import net.neoforged.neoforge.transfer.fluid.FluidUtil;
 import org.jetbrains.annotations.Nullable;
 
 /**
@@ -34,9 +34,12 @@ import org.jetbrains.annotations.Nullable;
 public class TankBlock extends BaseEntityBlock {
 
     public static final MapCodec<TankBlock> CODEC = RecordCodecBuilder.mapCodec(instance -> instance.group(
-            Codec.STRING.xmap(TankTier::valueOf, TankTier::name).fieldOf("tier").forGetter(TankBlock::tier),
-            propertiesCodec()
-    ).apply(instance, TankBlock::new));
+                    Codec.STRING
+                            .xmap(TankTier::valueOf, TankTier::name)
+                            .fieldOf("tier")
+                            .forGetter(TankBlock::tier),
+                    propertiesCodec())
+            .apply(instance, TankBlock::new));
 
     /** True when a connecting tank sits directly below, so the seamless {@code side_stacked} texture is used. */
     public static final BooleanProperty JOINED_BELOW = BooleanProperty.create("joined_below");
@@ -66,7 +69,12 @@ public class TankBlock extends BaseEntityBlock {
     /** Right-click with a bucket (or any fluid container) to fill the tank or fill the container from it. */
     @Override
     protected InteractionResult useItemOn(
-            ItemStack stack, BlockState state, Level level, BlockPos pos, Player player, InteractionHand hand,
+            ItemStack stack,
+            BlockState state,
+            Level level,
+            BlockPos pos,
+            Player player,
+            InteractionHand hand,
             BlockHitResult hit) {
         if (level.getBlockEntity(pos) instanceof TankBlockEntity
                 && FluidUtil.interactWithFluidHandler(player, hand, level, pos, hit.getDirection())) {
@@ -78,14 +86,21 @@ public class TankBlock extends BaseEntityBlock {
     @Nullable
     @Override
     public BlockState getStateForPlacement(BlockPlaceContext context) {
-        BlockState below = context.getLevel().getBlockState(context.getClickedPos().below());
+        BlockState below =
+                context.getLevel().getBlockState(context.getClickedPos().below());
         return defaultBlockState().setValue(JOINED_BELOW, joinsWithBelow(below));
     }
 
     @Override
     protected BlockState updateShape(
-            BlockState state, LevelReader level, ScheduledTickAccess scheduledTickAccess, BlockPos pos,
-            Direction direction, BlockPos neighborPos, BlockState neighborState, RandomSource random) {
+            BlockState state,
+            LevelReader level,
+            ScheduledTickAccess scheduledTickAccess,
+            BlockPos pos,
+            Direction direction,
+            BlockPos neighborPos,
+            BlockState neighborState,
+            RandomSource random) {
         if (direction == Direction.DOWN) {
             state = state.setValue(JOINED_BELOW, joinsWithBelow(neighborState));
         }
@@ -119,8 +134,10 @@ public class TankBlock extends BaseEntityBlock {
 
     @Nullable
     @Override
-    public <T extends BlockEntity> BlockEntityTicker<T> getTicker(Level level, BlockState state, BlockEntityType<T> type) {
-        return level.isClientSide() ? null
+    public <T extends BlockEntity> BlockEntityTicker<T> getTicker(
+            Level level, BlockState state, BlockEntityType<T> type) {
+        return level.isClientSide()
+                ? null
                 : createTickerHelper(type, IronTanksContent.TANK_BLOCK_ENTITY, TankBlockEntity::serverTick);
     }
 }

--- a/neoforge/src/main/java/com/indemnity83/irontanks/neoforge/content/TankBlockEntity.java
+++ b/neoforge/src/main/java/com/indemnity83/irontanks/neoforge/content/TankBlockEntity.java
@@ -7,6 +7,7 @@ import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Deque;
 import java.util.List;
+import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.nbt.CompoundTag;
@@ -20,8 +21,6 @@ import net.minecraft.world.level.storage.ValueInput;
 import net.minecraft.world.level.storage.ValueOutput;
 import net.neoforged.neoforge.transfer.fluid.FluidResource;
 import org.jetbrains.annotations.Nullable;
-
-import net.minecraft.core.BlockPos;
 
 /**
  * Stores a single fluid amount for one tank. Every connected tank in a vertical column holds the same
@@ -87,7 +86,8 @@ public class TankBlockEntity extends BlockEntity {
 
     // ==================== ticking ====================
 
-    public static void serverTick(net.minecraft.world.level.Level level, BlockPos pos, BlockState state, TankBlockEntity be) {
+    public static void serverTick(
+            net.minecraft.world.level.Level level, BlockPos pos, BlockState state, TankBlockEntity be) {
         be.tick();
     }
 
@@ -157,7 +157,8 @@ public class TankBlockEntity extends BlockEntity {
                 tank.setContentsRaw(targetFluid, target);
                 tank.setChanged();
                 if (level != null && !level.isClientSide()) {
-                    level.sendBlockUpdated(tank.worldPosition, tank.getBlockState(), tank.getBlockState(), Block.UPDATE_ALL);
+                    level.sendBlockUpdated(
+                            tank.worldPosition, tank.getBlockState(), tank.getBlockState(), Block.UPDATE_ALL);
                 }
                 changed = true;
             }

--- a/neoforge/src/main/java/com/indemnity83/irontanks/neoforge/content/TankBlockItem.java
+++ b/neoforge/src/main/java/com/indemnity83/irontanks/neoforge/content/TankBlockItem.java
@@ -19,15 +19,21 @@ public class TankBlockItem extends BlockItem {
 
     @Override
     public void appendHoverText(
-            ItemStack stack, Item.TooltipContext context, TooltipDisplay tooltipDisplay,
-            Consumer<Component> consumer, TooltipFlag flag) {
+            ItemStack stack,
+            Item.TooltipContext context,
+            TooltipDisplay tooltipDisplay,
+            Consumer<Component> consumer,
+            TooltipFlag flag) {
         super.appendHoverText(stack, context, tooltipDisplay, consumer, flag);
         TankTier tier = ((TankBlock) getBlock()).tier();
-        consumer.accept(Component.translatable("irontanks.tooltip.capacity", tier.buckets()).withStyle(ChatFormatting.GRAY));
+        consumer.accept(Component.translatable("irontanks.tooltip.capacity", tier.buckets())
+                .withStyle(ChatFormatting.GRAY));
         if (tier == TankTier.VOID) {
-            consumer.accept(Component.translatable("irontanks.tooltip.void_tank").withStyle(ChatFormatting.GRAY));
+            consumer.accept(
+                    Component.translatable("irontanks.tooltip.void_tank").withStyle(ChatFormatting.GRAY));
         } else if (tier == TankTier.CREATIVE) {
-            consumer.accept(Component.translatable("irontanks.tooltip.creative_tank").withStyle(ChatFormatting.GRAY));
+            consumer.accept(
+                    Component.translatable("irontanks.tooltip.creative_tank").withStyle(ChatFormatting.GRAY));
         }
     }
 }

--- a/neoforge/src/main/java/com/indemnity83/irontanks/neoforge/content/TankFluidHandler.java
+++ b/neoforge/src/main/java/com/indemnity83/irontanks/neoforge/content/TankFluidHandler.java
@@ -20,11 +20,9 @@ public final class TankFluidHandler extends SnapshotJournal<TankFluidHandler.Sna
         implements ResourceHandler<FluidResource> {
 
     /** A tank and its contents at transaction start, restored on abort. */
-    public record Slot(TankBlockEntity tank, FluidResource fluid, long amount) {
-    }
+    public record Slot(TankBlockEntity tank, FluidResource fluid, long amount) {}
 
-    public record Snapshot(List<Slot> slots) {
-    }
+    public record Snapshot(List<Slot> slots) {}
 
     private final TankBlockEntity origin;
 

--- a/resources/assets/irontanks/blockstates/copper_tank.json
+++ b/resources/assets/irontanks/blockstates/copper_tank.json
@@ -1,6 +1,10 @@
 {
   "variants": {
-    "joined_below=false": { "model": "irontanks:block/copper_tank" },
-    "joined_below=true": { "model": "irontanks:block/copper_tank_stacked" }
+    "joined_below=false": {
+      "model": "irontanks:block/copper_tank"
+    },
+    "joined_below=true": {
+      "model": "irontanks:block/copper_tank_stacked"
+    }
   }
 }

--- a/resources/assets/irontanks/blockstates/creative_tank.json
+++ b/resources/assets/irontanks/blockstates/creative_tank.json
@@ -1,6 +1,10 @@
 {
   "variants": {
-    "joined_below=false": { "model": "irontanks:block/creative_tank" },
-    "joined_below=true": { "model": "irontanks:block/creative_tank" }
+    "joined_below=false": {
+      "model": "irontanks:block/creative_tank"
+    },
+    "joined_below=true": {
+      "model": "irontanks:block/creative_tank"
+    }
   }
 }

--- a/resources/assets/irontanks/blockstates/diamond_tank.json
+++ b/resources/assets/irontanks/blockstates/diamond_tank.json
@@ -1,6 +1,10 @@
 {
   "variants": {
-    "joined_below=false": { "model": "irontanks:block/diamond_tank" },
-    "joined_below=true": { "model": "irontanks:block/diamond_tank_stacked" }
+    "joined_below=false": {
+      "model": "irontanks:block/diamond_tank"
+    },
+    "joined_below=true": {
+      "model": "irontanks:block/diamond_tank_stacked"
+    }
   }
 }

--- a/resources/assets/irontanks/blockstates/emerald_tank.json
+++ b/resources/assets/irontanks/blockstates/emerald_tank.json
@@ -1,6 +1,10 @@
 {
   "variants": {
-    "joined_below=false": { "model": "irontanks:block/emerald_tank" },
-    "joined_below=true": { "model": "irontanks:block/emerald_tank_stacked" }
+    "joined_below=false": {
+      "model": "irontanks:block/emerald_tank"
+    },
+    "joined_below=true": {
+      "model": "irontanks:block/emerald_tank_stacked"
+    }
   }
 }

--- a/resources/assets/irontanks/blockstates/glass_tank.json
+++ b/resources/assets/irontanks/blockstates/glass_tank.json
@@ -1,6 +1,10 @@
 {
   "variants": {
-    "joined_below=false": { "model": "irontanks:block/glass_tank" },
-    "joined_below=true": { "model": "irontanks:block/glass_tank_stacked" }
+    "joined_below=false": {
+      "model": "irontanks:block/glass_tank"
+    },
+    "joined_below=true": {
+      "model": "irontanks:block/glass_tank_stacked"
+    }
   }
 }

--- a/resources/assets/irontanks/blockstates/gold_tank.json
+++ b/resources/assets/irontanks/blockstates/gold_tank.json
@@ -1,6 +1,10 @@
 {
   "variants": {
-    "joined_below=false": { "model": "irontanks:block/gold_tank" },
-    "joined_below=true": { "model": "irontanks:block/gold_tank_stacked" }
+    "joined_below=false": {
+      "model": "irontanks:block/gold_tank"
+    },
+    "joined_below=true": {
+      "model": "irontanks:block/gold_tank_stacked"
+    }
   }
 }

--- a/resources/assets/irontanks/blockstates/iron_tank.json
+++ b/resources/assets/irontanks/blockstates/iron_tank.json
@@ -1,6 +1,10 @@
 {
   "variants": {
-    "joined_below=false": { "model": "irontanks:block/iron_tank" },
-    "joined_below=true": { "model": "irontanks:block/iron_tank_stacked" }
+    "joined_below=false": {
+      "model": "irontanks:block/iron_tank"
+    },
+    "joined_below=true": {
+      "model": "irontanks:block/iron_tank_stacked"
+    }
   }
 }

--- a/resources/assets/irontanks/blockstates/obsidian_tank.json
+++ b/resources/assets/irontanks/blockstates/obsidian_tank.json
@@ -1,6 +1,10 @@
 {
   "variants": {
-    "joined_below=false": { "model": "irontanks:block/obsidian_tank" },
-    "joined_below=true": { "model": "irontanks:block/obsidian_tank_stacked" }
+    "joined_below=false": {
+      "model": "irontanks:block/obsidian_tank"
+    },
+    "joined_below=true": {
+      "model": "irontanks:block/obsidian_tank_stacked"
+    }
   }
 }

--- a/resources/assets/irontanks/blockstates/silver_tank.json
+++ b/resources/assets/irontanks/blockstates/silver_tank.json
@@ -1,6 +1,10 @@
 {
   "variants": {
-    "joined_below=false": { "model": "irontanks:block/silver_tank" },
-    "joined_below=true": { "model": "irontanks:block/silver_tank_stacked" }
+    "joined_below=false": {
+      "model": "irontanks:block/silver_tank"
+    },
+    "joined_below=true": {
+      "model": "irontanks:block/silver_tank_stacked"
+    }
   }
 }

--- a/resources/assets/irontanks/blockstates/void_tank.json
+++ b/resources/assets/irontanks/blockstates/void_tank.json
@@ -1,6 +1,10 @@
 {
   "variants": {
-    "joined_below=false": { "model": "irontanks:block/void_tank" },
-    "joined_below=true": { "model": "irontanks:block/void_tank_stacked" }
+    "joined_below=false": {
+      "model": "irontanks:block/void_tank"
+    },
+    "joined_below=true": {
+      "model": "irontanks:block/void_tank_stacked"
+    }
   }
 }

--- a/resources/assets/irontanks/lang/en_us.json
+++ b/resources/assets/irontanks/lang/en_us.json
@@ -1,6 +1,5 @@
 {
   "itemGroup.irontanks.tanks": "Iron Tanks",
-
   "block.irontanks.glass_tank": "Glass Tank",
   "block.irontanks.copper_tank": "Copper Tank",
   "block.irontanks.iron_tank": "Iron Tank",
@@ -11,7 +10,6 @@
   "block.irontanks.emerald_tank": "Emerald Tank",
   "block.irontanks.void_tank": "Void Tank",
   "block.irontanks.creative_tank": "Creative Tank",
-
   "item.irontanks.glass_copper_upgrade": "Glass to Copper Tank Upgrade",
   "item.irontanks.glass_iron_upgrade": "Glass to Iron Tank Upgrade",
   "item.irontanks.copper_iron_upgrade": "Copper to Iron Tank Upgrade",
@@ -21,7 +19,6 @@
   "item.irontanks.gold_diamond_upgrade": "Gold to Diamond Tank Upgrade",
   "item.irontanks.diamond_obsidian_upgrade": "Diamond to Obsidian Tank Upgrade",
   "item.irontanks.diamond_emerald_upgrade": "Diamond to Emerald Tank Upgrade",
-
   "irontanks.tooltip.capacity": "Holds %s buckets",
   "irontanks.tooltip.void_tank": "Destroys fluids",
   "irontanks.tooltip.creative_tank": "Dispenses an infinite amount"

--- a/resources/assets/irontanks/models/block/tank.json
+++ b/resources/assets/irontanks/models/block/tank.json
@@ -6,15 +6,37 @@
   },
   "elements": [
     {
-      "from": [2, 0, 2],
-      "to": [14, 16, 14],
+      "from": [
+        2,
+        0,
+        2
+      ],
+      "to": [
+        14,
+        16,
+        14
+      ],
       "faces": {
-        "down": {"texture": "#end", "cullface": "down"},
-        "up": {"texture": "#end", "cullface": "up"},
-        "north": {"texture": "#side"},
-        "south": {"texture": "#side"},
-        "west": {"texture": "#side"},
-        "east": {"texture": "#side"}
+        "down": {
+          "texture": "#end",
+          "cullface": "down"
+        },
+        "up": {
+          "texture": "#end",
+          "cullface": "up"
+        },
+        "north": {
+          "texture": "#side"
+        },
+        "south": {
+          "texture": "#side"
+        },
+        "west": {
+          "texture": "#side"
+        },
+        "east": {
+          "texture": "#side"
+        }
       }
     }
   ]

--- a/settings.gradle
+++ b/settings.gradle
@@ -14,6 +14,7 @@ pluginManagement {
         // Versions come from gradle.properties so subproject plugins {} blocks omit them.
         id 'net.fabricmc.fabric-loom' version "${loom_version}"
         id 'net.neoforged.moddev' version "${moddev_version}"
+        id 'com.diffplug.spotless' version "${spotless_version}"
     }
 }
 


### PR DESCRIPTION
## Summary

Splits the single `Check Code` job into three focused stages and adds an enforced code-format gate. Previously one `./gradlew build` ran everything, so a formatting nit, a failed unit test, and a loader that won't compile all looked like the same opaque "build failed."

## Changes

- **lint** — new Spotless format gate (`spotlessCheck`): `palantir-java-format` for Java (4-space, matches `.editorconfig`), gson for JSON resources. `./gradlew spotlessApply` auto-fixes.
- **test** — runs `core`'s JUnit suite (`:core:test`), the only module with tests today.
- **build** — a `[fabric, neoforge]` matrix that smoke-builds each loader jar, running only after `lint` + `test` pass (so we don't spend the heavier loader build on a trivially-broken PR).
- Extracted the repeated JDK 25 + Gradle setup into a `setup-build` composite action.
- One-time `spotlessApply` reformat across Java + JSON (its own commit).
- Updated `CLAUDE.md` / `AGENTS.md` to reflect the new format gate and CI layout.

## Notes

- **Why Spotless over Prettier:** Spotless is Gradle-native (reuses the JDK/Gradle setup, no Node toolchain). The JSON step uses Spotless's native gson formatter, so even the resource formatting needs no Node.
- Loaders have no test/gametest source set yet — the build matrix is their coverage for now. Real in-game/gametest runs are a future follow-up.
- Adopting the `setup-build` composite action in the release/snapshot/prerelease workflows is a deliberate follow-up to keep this PR focused.