### PR TITLE
feat: add opt-in crash reporting

### DIFF
--- a/.github/workflows/build-prerelease.yml
+++ b/.github/workflows/build-prerelease.yml
@@ -14,6 +14,9 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
+    # Mapped to a job env so the "Create Sentry release" step can gate on it (secrets can't be used in `if`).
+    env:
+      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
     strategy:
       fail-fast: false
       max-parallel: 1
@@ -79,6 +82,7 @@ jobs:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
 
       - name: Create Sentry release
+        if: ${{ env.SENTRY_AUTH_TOKEN != '' }}
         uses: getsentry/action-release@ff07929a6537bac57790c3451cf4d364aca38528 # v3.7.0
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}

--- a/.github/workflows/build-prerelease.yml
+++ b/.github/workflows/build-prerelease.yml
@@ -75,6 +75,21 @@ jobs:
         run: ./gradlew :${{ matrix.loader }}:jar --console=plain
         env:
           MOD_VERSION: ${{ steps.version.outputs.full_version }}
+          # Enables Sentry source-context upload during the build (gated on the token being present).
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+
+      - name: Create Sentry release
+        uses: getsentry/action-release@ff07929a6537bac57790c3451cf4d364aca38528 # v3.7.0
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: indmenity83
+          SENTRY_PROJECT: irontanks-mod
+        with:
+          release: irontanks@${{ steps.version.outputs.full_version }}
+          set_commits: auto
+          finalize: true
+          # Pre-releases (betas) stay out of the production deploy stream.
+          environment: preview
 
       - name: Upload JAR
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -31,6 +31,8 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ inputs.tag || github.ref }}
+          # Full history so the Sentry release step can auto-associate commits.
+          fetch-depth: 0
           persist-credentials: false
 
       - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
@@ -85,9 +87,25 @@ jobs:
         run: ./gradlew :${{ matrix.loader }}:jar --console=plain
         env:
           MOD_VERSION: ${{ steps.version.outputs.full_version }}
+          # Enables Sentry source-context upload during the build (gated on the token being present).
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
 
       - name: List build artifacts
         run: ls -lh ${{ matrix.loader }}/build/libs/
+
+      - name: Create Sentry release
+        if: github.event_name != 'workflow_dispatch' || inputs.publish
+        uses: getsentry/action-release@ff07929a6537bac57790c3451cf4d364aca38528 # v3.7.0
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: indmenity83
+          SENTRY_PROJECT: irontanks-mod
+        with:
+          # Matches the runtime SDK's release: "irontanks@" + modVersion (one per loader jar).
+          release: irontanks@${{ steps.version.outputs.full_version }}
+          set_commits: auto
+          finalize: true
+          environment: production
 
       - name: Upload JAR
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -21,6 +21,9 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
+    # Mapped to a job env so the "Create Sentry release" step can gate on it (secrets can't be used in `if`).
+    env:
+      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
     strategy:
       fail-fast: false
       max-parallel: 1
@@ -94,7 +97,7 @@ jobs:
         run: ls -lh ${{ matrix.loader }}/build/libs/
 
       - name: Create Sentry release
-        if: github.event_name != 'workflow_dispatch' || inputs.publish
+        if: ${{ (github.event_name != 'workflow_dispatch' || inputs.publish) && env.SENTRY_AUTH_TOKEN != '' }}
         uses: getsentry/action-release@ff07929a6537bac57790c3451cf4d364aca38528 # v3.7.0
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}

--- a/.github/workflows/build-snapshot.yml
+++ b/.github/workflows/build-snapshot.yml
@@ -14,6 +14,9 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
+    # Mapped to a job env so the "Create Sentry release" step can gate on it (secrets can't be used in `if`).
+    env:
+      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
     strategy:
       fail-fast: false
       max-parallel: 1
@@ -76,6 +79,7 @@ jobs:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
 
       - name: Create Sentry release
+        if: ${{ env.SENTRY_AUTH_TOKEN != '' }}
         uses: getsentry/action-release@ff07929a6537bac57790c3451cf4d364aca38528 # v3.7.0
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}

--- a/.github/workflows/build-snapshot.yml
+++ b/.github/workflows/build-snapshot.yml
@@ -72,6 +72,21 @@ jobs:
         run: ./gradlew :${{ matrix.loader }}:jar --console=plain
         env:
           MOD_VERSION: ${{ steps.version.outputs.full_version }}
+          # Enables Sentry source-context upload during the build (gated on the token being present).
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+
+      - name: Create Sentry release
+        uses: getsentry/action-release@ff07929a6537bac57790c3451cf4d364aca38528 # v3.7.0
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: indmenity83
+          SENTRY_PROJECT: irontanks-mod
+        with:
+          release: irontanks@${{ steps.version.outputs.full_version }}
+          set_commits: auto
+          finalize: true
+          # Snapshots are pre-release; keep them out of the production deploy stream.
+          environment: preview
 
       - name: Upload JAR
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/CRASH_REPORTING.md
+++ b/CRASH_REPORTING.md
@@ -1,0 +1,63 @@
+# Crash Reporting & Privacy
+
+Iron Tanks can send **sanitized crash reports** to help us find and fix bugs you hit in the wild.
+It is **opt-in and off by default** — nothing is ever sent until an operator turns it on.
+
+## TL;DR
+
+- **Off by default.** Fresh installs send nothing.
+- **Opt-in per world/server**, via `/irontanks diagnostics enable`. Turn it back off any time with
+  `/irontanks diagnostics disable`.
+- **Only Iron Tanks' own errors** are captured — never another mod's or vanilla Minecraft's.
+- **Personal info is stripped** before anything leaves your machine (see below).
+- Reports go to [Sentry](https://sentry.io/), a standard crash-reporting service.
+
+## How to turn it on or off
+
+You need operator/gamemaster permission. In chat or the server console:
+
+| Command | What it does |
+|---|---|
+| `/irontanks diagnostics` | Show whether reporting is currently ON or OFF |
+| `/irontanks diagnostics enable` | Start sending sanitized crash reports |
+| `/irontanks diagnostics disable` | Stop sending crash reports |
+| `/irontanks diagnostics preview` | Print a sample of exactly what a report looks like — **nothing is sent** |
+| `/irontanks diagnostics notify off` | Hide the join-time reminder for operators |
+| `/irontanks diagnostics notify on` | Show the join-time reminder again |
+
+Your choice is saved to `config/irontanks.json` and persists across restarts.
+
+## What is collected (only when enabled)
+
+- The error itself: exception type, message, and stack trace from Iron Tanks code.
+- Versions: the Iron Tanks version, Minecraft version, loader (Fabric/NeoForge), and Java/OS family.
+
+## What is **never** collected
+
+- Player names, UUIDs, or IP addresses
+- Server names/hostnames
+- Chat messages, world data, coordinates, or builds
+- The contents of your config files
+- Anything that looks like a password, token, API key, or secret
+
+## How sanitizing works
+
+Before any report leaves your machine, the message and exception text are scrubbed — biased toward
+over-redaction (when in doubt, it strips):
+
+- Your home directory and username → `~` / `<user>`
+- Generic `…/Users/<name>`, `…/home/<name>`, and `C:\Users\<name>` paths → redacted
+- UUIDs → `<uuid>`
+- IPv4 addresses → `<ip>`
+- `password=…`, `token=…`, `secret=…`, `api_key=…`, `dsn=…` pairs → `<redacted>`
+
+Stack frames carry only source file names, not full paths, so they need no scrubbing. Run
+`/irontanks diagnostics preview` to see the result for yourself before opting in.
+
+## Technical notes
+
+- The DSN (the public ingest key) is embedded in the mod. DSNs are **write-only** and designed to
+  ship in client software — it can submit reports but can't read anything back.
+- Iron Tanks uses its own dedicated Sentry client and never touches the global Sentry SDK, so it
+  can't interfere with any other mod that also uses Sentry.
+- Self-hosting Sentry? Set `crashReporting.dsnOverride` in `config/irontanks.json` to your own DSN.

--- a/README.md
+++ b/README.md
@@ -53,6 +53,14 @@ Grab the latest build for your loader from
 > Minecraft 1.12.2 and earlier live on the `mc/*` branches and remain BuildCraft add-ons — see those
 > releases.
 
+## Crash reporting (opt-in)
+
+Iron Tanks can send **sanitized crash reports** to help fix bugs — but it's **off by default** and
+sends nothing until an operator turns it on with `/irontanks diagnostics enable`. Only Iron Tanks'
+own errors are captured, and personal info (usernames, paths, IPs, UUIDs, secrets) is stripped before
+anything leaves your machine. Run `/irontanks diagnostics preview` to see exactly what a report looks
+like. Full details in **[CRASH_REPORTING.md](CRASH_REPORTING.md)**.
+
 ## Contributing
 
 You don't need to write Java to help:

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -15,10 +15,22 @@ repositories {
 }
 
 dependencies {
+    // Crash reporting (com.indemnity83.irontanks.core.crash). All three are provided at runtime —
+    // Sentry by each loader's jar-in-jar bundle, Gson + Log4j2 by Minecraft — so they are compileOnly
+    // here (never bundled by core) and testImplementation so the pure-logic tests can exercise them.
+    compileOnly "io.sentry:sentry:${rootProject.sentry_version}"
+    compileOnly "com.google.code.gson:gson:${rootProject.gson_version}"
+    compileOnly "org.apache.logging.log4j:log4j-core:${rootProject.log4j_version}"
+    compileOnly "org.slf4j:slf4j-api:${rootProject.slf4j_version}"
+
     testImplementation platform("org.junit:junit-bom:${rootProject.junit_version}")
     testImplementation 'org.junit.jupiter:junit-jupiter'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     testImplementation "org.assertj:assertj-core:${rootProject.assertj_version}"
+    testImplementation "io.sentry:sentry:${rootProject.sentry_version}"
+    testImplementation "com.google.code.gson:gson:${rootProject.gson_version}"
+    testImplementation "org.apache.logging.log4j:log4j-core:${rootProject.log4j_version}"
+    testRuntimeOnly "org.slf4j:slf4j-api:${rootProject.slf4j_version}"
 }
 
 test {

--- a/core/src/main/java/com/indemnity83/irontanks/core/crash/CrashReporting.java
+++ b/core/src/main/java/com/indemnity83/irontanks/core/crash/CrashReporting.java
@@ -1,0 +1,313 @@
+package com.indemnity83.irontanks.core.crash;
+
+import io.sentry.ISentryClient;
+import io.sentry.SentryClient;
+import io.sentry.SentryEvent;
+import io.sentry.SentryOptions;
+import io.sentry.protocol.Message;
+import io.sentry.protocol.SentryException;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Function;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The crash-reporting orchestrator: opt-in (default OFF), Iron-Tanks-only, sanitized Sentry
+ * reporting. Pure Java — it depends on the Sentry SDK, {@link LogScrubber}, {@link Log4j2Bridge} and
+ * {@link IronTanksConfig}, but never on Minecraft. Each loader calls {@link #bootstrap} once at init
+ * with a {@link PlatformInfo} and its config path; the {@code /irontanks diagnostics} commands drive
+ * {@link #enable()} / {@link #disable()}, which keep the persisted config and the live Sentry client
+ * in lock-step so they can never drift.
+ *
+ * <p>It builds a <em>dedicated</em> {@link SentryClient} and never calls {@code Sentry.init()}, so it
+ * can't clobber a global Sentry SDK that another mod might bundle.
+ */
+public final class CrashReporting {
+
+    private CrashReporting() {}
+
+    private static final Logger LOGGER = LoggerFactory.getLogger("irontanks/crash");
+
+    /**
+     * Public Sentry ingest key (DSN). NOT a secret — DSNs are write-only and designed to be embedded
+     * in shipped clients. Overridable per-install via {@code crashReporting.dsnOverride}.
+     */
+    public static final String DEFAULT_DSN =
+            "https://ccf7650d1be5ce1b785b1ff51dd064f3@o148290.ingest.us.sentry.io/4511502294908928";
+
+    private static final long FLUSH_TIMEOUT_MS = 2_000L;
+
+    private static final AtomicBoolean ACTIVE = new AtomicBoolean(false);
+    private static final AtomicBoolean SHUTDOWN_HOOK_REGISTERED = new AtomicBoolean(false);
+
+    private static volatile ISentryClient client;
+    private static volatile Log4j2Bridge bridge;
+    private static volatile PlatformInfo platform;
+    private static volatile Path configFile;
+    private static volatile IronTanksConfig config;
+    private static volatile String dsn = DEFAULT_DSN;
+
+    // Test seam: how the live client is built. Default uses the real async-HTTP Sentry client.
+    private static Function<SentryOptions, ISentryClient> clientFactory = SentryClient::new;
+
+    /**
+     * Load config and, if crash reporting was left enabled, start it. Call once per loader during
+     * init. {@code dsn} is normally {@link #DEFAULT_DSN}; the config's {@code dsnOverride} wins when set.
+     */
+    public static synchronized void bootstrap(PlatformInfo platformInfo, Path file, String dsnValue) {
+        platform = platformInfo;
+        configFile = file;
+        dsn = (dsnValue == null || dsnValue.isBlank()) ? DEFAULT_DSN : dsnValue;
+        config = IronTanksConfig.load(file);
+        if (config.crashReporting().enabled()) {
+            start();
+        }
+    }
+
+    /** Turn reporting on: persist the choice and start the client + log bridge. Idempotent. */
+    public static synchronized boolean enable() {
+        if (config == null) {
+            LOGGER.warn("Crash reporting enable() called before bootstrap()");
+            return false;
+        }
+        config.crashReporting().setEnabled(true);
+        persist();
+        return ACTIVE.get() || start();
+    }
+
+    /** Turn reporting off: persist the choice and flush + close the client. Idempotent. */
+    public static synchronized void disable() {
+        if (config != null) {
+            config.crashReporting().setEnabled(false);
+            persist();
+        }
+        stop();
+    }
+
+    public static boolean isActive() {
+        return ACTIVE.get();
+    }
+
+    /** Whether reporting is configured on (persisted), independent of whether the client is live. */
+    public static boolean isEnabled() {
+        return config != null && config.crashReporting().enabled();
+    }
+
+    public static boolean notifyOperators() {
+        return config != null && config.crashReporting().notifyOperators();
+    }
+
+    /** Persist the operator join-notice preference. Returns the new value for convenience. */
+    public static synchronized boolean setNotifyOperators(boolean value) {
+        if (config != null) {
+            config.crashReporting().setNotifyOperators(value);
+            persist();
+        }
+        return value;
+    }
+
+    public static PlatformInfo platform() {
+        return platform;
+    }
+
+    /** Forward a throwable to Sentry if reporting is live. No-op (never throws) otherwise. */
+    public static void capture(Throwable throwable) {
+        if (throwable == null || !ACTIVE.get()) {
+            return;
+        }
+        ISentryClient current = client;
+        if (current != null) {
+            try {
+                current.captureException(throwable);
+            } catch (Throwable t) {
+                LOGGER.warn("Failed to capture crash report: {}", t.toString());
+            }
+        }
+    }
+
+    /** Send a synthetic report to verify the pipeline. Returns false if reporting isn't live. */
+    public static synchronized boolean sendTestReport() {
+        if (!ACTIVE.get()) {
+            return false;
+        }
+        ISentryClient current = client;
+        if (current == null) {
+            return false;
+        }
+        current.captureException(new IllegalStateException("Iron Tanks crash-reporting test event"));
+        return true;
+    }
+
+    /**
+     * Render a sanitized example of what a report would look like — built and scrubbed, but never
+     * sent and never touching the client. Backs {@code /irontanks diagnostics preview}.
+     */
+    public static synchronized String previewReport() {
+        SentryEvent event = new SentryEvent();
+        Message message = new Message();
+        String user = System.getProperty("user.name");
+        String home = System.getProperty("user.home");
+        message.setMessage("Example captured error: failed saving tank for player "
+                + "550e8400-e29b-41d4-a716-446655440000 at "
+                + (home == null ? "/home/" + user : home)
+                + "/saves from 203.0.113.7 (token=s3cr3t-abc123)");
+        message.setFormatted(message.getMessage());
+        event.setMessage(message);
+
+        SentryException exception = new SentryException();
+        exception.setType("java.lang.IllegalStateException");
+        exception.setValue("Tank column desync at /home/" + (user == null ? "player" : user) + "/world");
+        event.setExceptions(List.of(exception));
+
+        LogScrubber.scrub(event);
+        return renderPreview(event);
+    }
+
+    private static String renderPreview(SentryEvent event) {
+        StringBuilder sb = new StringBuilder("Iron Tanks crash-report preview (nothing is sent):\n");
+        if (platform != null) {
+            sb.append("  release: irontanks@").append(platform.modVersion()).append('\n');
+            sb.append("  environment: ")
+                    .append(platform.developmentEnvironment() ? "development" : "production")
+                    .append('\n');
+            sb.append("  tags: loader=")
+                    .append(platform.loaderName())
+                    .append(", minecraft_version=")
+                    .append(platform.minecraftVersion())
+                    .append('\n');
+        }
+        Message message = event.getMessage();
+        if (message != null && message.getMessage() != null) {
+            sb.append("  message: ").append(message.getMessage()).append('\n');
+        }
+        if (event.getExceptions() != null) {
+            for (SentryException ex : event.getExceptions()) {
+                sb.append("  exception: ")
+                        .append(ex.getType())
+                        .append(": ")
+                        .append(ex.getValue())
+                        .append('\n');
+            }
+        }
+        return sb.toString();
+    }
+
+    private static boolean start() {
+        if (ACTIVE.get()) {
+            return true;
+        }
+        String effectiveDsn = effectiveDsn();
+        if (effectiveDsn.isBlank()) {
+            LOGGER.warn("Crash reporting enabled but no DSN is configured; not starting");
+            return false;
+        }
+        try {
+            client = clientFactory.apply(buildOptions(effectiveDsn));
+            registerShutdownHookOnce();
+            bridge = new Log4j2Bridge(CrashReporting::capture);
+            bridge.attach();
+            ACTIVE.set(true);
+            LOGGER.info(
+                    "Crash reporting enabled (release=irontanks@{}, loader={})",
+                    platform != null ? platform.modVersion() : "unknown",
+                    platform != null ? platform.loaderName() : "unknown");
+            return true;
+        } catch (Throwable t) {
+            LOGGER.warn("Failed to start crash reporting: {}", t.toString());
+            client = null;
+            bridge = null;
+            ACTIVE.set(false);
+            return false;
+        }
+    }
+
+    private static void stop() {
+        if (!ACTIVE.getAndSet(false)) {
+            return;
+        }
+        if (bridge != null) {
+            bridge.detach();
+            bridge = null;
+        }
+        ISentryClient current = client;
+        client = null;
+        if (current != null) {
+            try {
+                current.flush(FLUSH_TIMEOUT_MS);
+                current.close();
+            } catch (Throwable t) {
+                LOGGER.warn("Error closing crash reporter: {}", t.toString());
+            }
+        }
+        LOGGER.info("Crash reporting disabled");
+    }
+
+    private static SentryOptions buildOptions(String effectiveDsn) {
+        boolean dev = platform != null && platform.developmentEnvironment();
+        SentryOptions options = new SentryOptions();
+        options.setDsn(effectiveDsn);
+        options.setEnableUncaughtExceptionHandler(false);
+        options.setSendDefaultPii(false);
+        options.setAttachServerName(false);
+        options.setEnableExternalConfiguration(false);
+        if (platform != null) {
+            options.setRelease("irontanks@" + platform.modVersion());
+            options.setTag("loader", platform.loaderName());
+            options.setTag("minecraft_version", platform.minecraftVersion());
+            options.setTag("mod_version", platform.modVersion());
+        }
+        options.setEnvironment(dev ? "development" : "production");
+        options.setBeforeSend((event, hint) -> LogScrubber.scrub(event));
+        options.setDebug(dev);
+        return options;
+    }
+
+    private static String effectiveDsn() {
+        if (config != null) {
+            String override = config.crashReporting().dsnOverride();
+            if (!override.isBlank()) {
+                return override.trim();
+            }
+        }
+        return dsn == null ? "" : dsn;
+    }
+
+    private static void persist() {
+        if (config != null && configFile != null) {
+            config.save(configFile);
+        }
+    }
+
+    private static void registerShutdownHookOnce() {
+        if (SHUTDOWN_HOOK_REGISTERED.compareAndSet(false, true)) {
+            Runtime.getRuntime().addShutdownHook(new Thread(CrashReporting::flushOnExit, "irontanks-sentry-flush"));
+        }
+    }
+
+    private static void flushOnExit() {
+        ISentryClient current = client;
+        if (current != null) {
+            try {
+                current.flush(FLUSH_TIMEOUT_MS);
+            } catch (Throwable ignored) {
+                // best-effort flush on JVM shutdown
+            }
+        }
+    }
+
+    // --- test-only hooks -------------------------------------------------------------------------
+
+    /** Swap the client factory and clear all state so each unit test starts clean. */
+    static synchronized void resetForTesting(Function<SentryOptions, ISentryClient> factory) {
+        stop();
+        clientFactory = factory != null ? factory : SentryClient::new;
+        config = null;
+        platform = null;
+        configFile = null;
+        dsn = DEFAULT_DSN;
+        // Block real JVM shutdown hooks from being registered during tests.
+        SHUTDOWN_HOOK_REGISTERED.set(true);
+    }
+}

--- a/core/src/main/java/com/indemnity83/irontanks/core/crash/CrashReportingConfig.java
+++ b/core/src/main/java/com/indemnity83/irontanks/core/crash/CrashReportingConfig.java
@@ -1,0 +1,42 @@
+package com.indemnity83.irontanks.core.crash;
+
+/**
+ * The {@code crashReporting} section of {@link IronTanksConfig}. Opt-in: everything stays off until
+ * an operator runs {@code /irontanks diagnostics enable}. Gson (de)serializes the private fields by
+ * name, so the on-disk shape is {@code {"enabled": false, "notifyOperators": true, "dsnOverride": ""}}.
+ */
+public final class CrashReportingConfig {
+
+    /** Whether sanitized crash reports are sent. Opt-in: off until an operator enables it. */
+    private boolean enabled = false;
+
+    /** Whether operators are invited to opt in on join (until they silence the notice). */
+    private boolean notifyOperators = true;
+
+    /** Optional DSN override for self-hosting/testing; empty uses the bundled default. */
+    private String dsnOverride = "";
+
+    public boolean enabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public boolean notifyOperators() {
+        return notifyOperators;
+    }
+
+    public void setNotifyOperators(boolean notifyOperators) {
+        this.notifyOperators = notifyOperators;
+    }
+
+    public String dsnOverride() {
+        return dsnOverride == null ? "" : dsnOverride;
+    }
+
+    public void setDsnOverride(String dsnOverride) {
+        this.dsnOverride = dsnOverride;
+    }
+}

--- a/core/src/main/java/com/indemnity83/irontanks/core/crash/IronTanksConfig.java
+++ b/core/src/main/java/com/indemnity83/irontanks/core/crash/IronTanksConfig.java
@@ -1,0 +1,77 @@
+package com.indemnity83.irontanks.core.crash;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Iron Tanks' general configuration file (a single {@code config/irontanks.json}). Today it holds
+ * only the {@link CrashReportingConfig} section, but it's shaped as a general config root so future
+ * settings are just new fields here. Pure Gson file I/O — the config-dir {@link Path} is injected by
+ * each loader, so {@code core} stays free of Minecraft.
+ *
+ * <p>Reads and writes are best-effort: a missing or corrupt file yields defaults (and rewrites a
+ * clean file) rather than throwing into callers, so a bad config can never break mod load.
+ */
+public final class IronTanksConfig {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger("irontanks/config");
+    private static final Gson GSON = new GsonBuilder().setPrettyPrinting().create();
+
+    private CrashReportingConfig crashReporting = new CrashReportingConfig();
+
+    public CrashReportingConfig crashReporting() {
+        if (crashReporting == null) {
+            crashReporting = new CrashReportingConfig();
+        }
+        return crashReporting;
+    }
+
+    /**
+     * Load the config from {@code file}. A missing file is created with defaults; a corrupt file
+     * falls back to defaults (and is left as-is on disk only if it can't be rewritten). Never throws.
+     */
+    public static IronTanksConfig load(Path file) {
+        if (file == null) {
+            return new IronTanksConfig();
+        }
+        try {
+            if (Files.exists(file)) {
+                IronTanksConfig parsed = GSON.fromJson(Files.readString(file), IronTanksConfig.class);
+                if (parsed != null) {
+                    parsed.ensureSections();
+                    return parsed;
+                }
+            }
+        } catch (Exception e) {
+            LOGGER.warn("Could not read {}; using defaults: {}", file, e.toString());
+        }
+        IronTanksConfig defaults = new IronTanksConfig();
+        defaults.save(file);
+        return defaults;
+    }
+
+    /** Persist the current values to {@code file}, creating parent directories as needed. Never throws. */
+    public void save(Path file) {
+        if (file == null) {
+            return;
+        }
+        try {
+            if (file.getParent() != null) {
+                Files.createDirectories(file.getParent());
+            }
+            Files.writeString(file, GSON.toJson(this));
+        } catch (Exception e) {
+            LOGGER.warn("Could not write {}: {}", file, e.toString());
+        }
+    }
+
+    private void ensureSections() {
+        if (crashReporting == null) {
+            crashReporting = new CrashReportingConfig();
+        }
+    }
+}

--- a/core/src/main/java/com/indemnity83/irontanks/core/crash/Log4j2Bridge.java
+++ b/core/src/main/java/com/indemnity83/irontanks/core/crash/Log4j2Bridge.java
@@ -1,0 +1,98 @@
+package com.indemnity83.irontanks.core.crash;
+
+import java.util.Locale;
+import java.util.function.Consumer;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.config.Configuration;
+import org.apache.logging.log4j.core.config.Property;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Routes Iron Tanks' own {@code ERROR}-level log events that carry a throwable into the crash
+ * reporter. It attaches a forwarding appender to the Log4j2 root logger (Minecraft's logging
+ * backend) rather than a single named logger, then filters by logger name so only our errors are
+ * captured — never another mod's or vanilla's.
+ *
+ * <p>Log4j2 is a {@code compileOnly} dependency provided by Minecraft at runtime. Attach/detach are
+ * guarded so that if the backend isn't Log4j2 (or anything else goes wrong) the bridge degrades to a
+ * no-op instead of breaking. The routing predicate {@link #shouldForward} is pure and unit-tested.
+ */
+public final class Log4j2Bridge {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger("irontanks/crash");
+    private static final String APPENDER_NAME = "IronTanksSentryBridge";
+
+    private final Consumer<Throwable> sink;
+    private ForwardingAppender appender;
+
+    public Log4j2Bridge(Consumer<Throwable> sink) {
+        this.sink = sink;
+    }
+
+    /**
+     * True when an event should be forwarded: it carries a throwable and originates from an Iron
+     * Tanks logger. Parameterized over primitives so it's testable without constructing a Log4j2
+     * {@link LogEvent}.
+     */
+    public static boolean shouldForward(String loggerName, boolean hasThrowable) {
+        if (!hasThrowable || loggerName == null) {
+            return false;
+        }
+        String lower = loggerName.toLowerCase(Locale.ROOT);
+        return lower.startsWith("irontanks") || lower.contains("com.indemnity83.irontanks");
+    }
+
+    public void attach() {
+        try {
+            if (!(LogManager.getContext(false) instanceof LoggerContext ctx)) {
+                LOGGER.warn("Log4j2 backend unavailable; crash log capture disabled");
+                return;
+            }
+            Configuration config = ctx.getConfiguration();
+            appender = new ForwardingAppender(APPENDER_NAME, sink);
+            appender.start();
+            config.getRootLogger().addAppender(appender, Level.ERROR, null);
+            ctx.updateLoggers();
+        } catch (Throwable t) {
+            LOGGER.warn("Failed to attach crash log capture: {}", t.toString());
+            appender = null;
+        }
+    }
+
+    public void detach() {
+        try {
+            if (appender == null || !(LogManager.getContext(false) instanceof LoggerContext ctx)) {
+                return;
+            }
+            ctx.getConfiguration().getRootLogger().removeAppender(APPENDER_NAME);
+            appender.stop();
+            ctx.updateLoggers();
+        } catch (Throwable t) {
+            LOGGER.warn("Failed to detach crash log capture: {}", t.toString());
+        } finally {
+            appender = null;
+        }
+    }
+
+    private static final class ForwardingAppender extends AbstractAppender {
+
+        private final Consumer<Throwable> sink;
+
+        ForwardingAppender(String name, Consumer<Throwable> sink) {
+            super(name, null, null, true, Property.EMPTY_ARRAY);
+            this.sink = sink;
+        }
+
+        @Override
+        public void append(LogEvent event) {
+            if (shouldForward(event.getLoggerName(), event.getThrown() != null)) {
+                sink.accept(event.getThrown());
+            }
+        }
+    }
+}

--- a/core/src/main/java/com/indemnity83/irontanks/core/crash/LogScrubber.java
+++ b/core/src/main/java/com/indemnity83/irontanks/core/crash/LogScrubber.java
@@ -64,8 +64,10 @@ public final class LogScrubber {
         if (home != null && !home.isBlank()) {
             value = value.replace(home, "~");
         }
-        if (user != null && !user.isBlank()) {
-            value = value.replace(user, "<user>");
+        // Whole-word match only, and skip very short logins, so a common username like "root" can't
+        // mangle unrelated text such as "rootCause". (Home-dir paths are handled separately above.)
+        if (user != null && user.length() >= 3) {
+            value = value.replaceAll("\\b" + Pattern.quote(user) + "\\b", "<user>");
         }
         value = UNIX_HOME.matcher(value).replaceAll("$1/<user>");
         value = WINDOWS_HOME.matcher(value).replaceAll("$1<user>");

--- a/core/src/main/java/com/indemnity83/irontanks/core/crash/LogScrubber.java
+++ b/core/src/main/java/com/indemnity83/irontanks/core/crash/LogScrubber.java
@@ -1,0 +1,77 @@
+package com.indemnity83.irontanks.core.crash;
+
+import io.sentry.Breadcrumb;
+import io.sentry.SentryEvent;
+import io.sentry.protocol.Message;
+import io.sentry.protocol.SentryException;
+import java.util.regex.Pattern;
+
+/**
+ * Strips identifying substrings from an event before it leaves the process. Best-effort and
+ * intentionally biased toward over-redaction: when in doubt, it strips. Pure string work, so the
+ * whole thing is unit-tested in {@code core} without a running game.
+ *
+ * <p>Stack frames carry only source file names (not absolute paths), so only free-text fields —
+ * the message, exception values, and breadcrumb messages — need scrubbing.
+ */
+public final class LogScrubber {
+
+    private LogScrubber() {}
+
+    private static final Pattern IPV4 = Pattern.compile("\\b\\d{1,3}(?:\\.\\d{1,3}){3}\\b");
+    private static final Pattern UUID =
+            Pattern.compile("\\b[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\\b");
+    private static final Pattern UNIX_HOME = Pattern.compile("(/(?:Users|home))/[^/\\s]+");
+    private static final Pattern WINDOWS_HOME = Pattern.compile("([A-Za-z]:\\\\Users\\\\)[^\\\\\\s]+");
+    private static final Pattern SECRET_KV =
+            Pattern.compile("(?i)(password|passwd|token|secret|api[_-]?key|access[_-]?key|dsn)(\\s*[=:]\\s*)\\S+");
+
+    /** Scrub an event in place (message, exception values, breadcrumb messages) and drop the server name. */
+    public static SentryEvent scrub(SentryEvent event) {
+        if (event == null) {
+            return null;
+        }
+        event.setServerName(null);
+        Message message = event.getMessage();
+        if (message != null) {
+            message.setFormatted(redact(message.getFormatted()));
+            message.setMessage(redact(message.getMessage()));
+        }
+        if (event.getExceptions() != null) {
+            for (SentryException ex : event.getExceptions()) {
+                ex.setValue(redact(ex.getValue()));
+            }
+        }
+        if (event.getBreadcrumbs() != null) {
+            for (Breadcrumb breadcrumb : event.getBreadcrumbs()) {
+                breadcrumb.setMessage(redact(breadcrumb.getMessage()));
+            }
+        }
+        return event;
+    }
+
+    /**
+     * Redact identifying substrings from a single string: this machine's home dir / username, generic
+     * {@code /Users|/home/<name>} and {@code C:\Users\<name>} paths, UUIDs, IPv4 addresses, and
+     * secret-like {@code key=value} pairs. Idempotent — running it twice is stable.
+     */
+    public static String redact(String value) {
+        if (value == null || value.isEmpty()) {
+            return value;
+        }
+        String home = System.getProperty("user.home");
+        String user = System.getProperty("user.name");
+        if (home != null && !home.isBlank()) {
+            value = value.replace(home, "~");
+        }
+        if (user != null && !user.isBlank()) {
+            value = value.replace(user, "<user>");
+        }
+        value = UNIX_HOME.matcher(value).replaceAll("$1/<user>");
+        value = WINDOWS_HOME.matcher(value).replaceAll("$1<user>");
+        value = UUID.matcher(value).replaceAll("<uuid>");
+        value = IPV4.matcher(value).replaceAll("<ip>");
+        value = SECRET_KV.matcher(value).replaceAll("$1$2<redacted>");
+        return value;
+    }
+}

--- a/core/src/main/java/com/indemnity83/irontanks/core/crash/PlatformInfo.java
+++ b/core/src/main/java/com/indemnity83/irontanks/core/crash/PlatformInfo.java
@@ -1,0 +1,14 @@
+package com.indemnity83.irontanks.core.crash;
+
+/**
+ * Loader/environment facts the crash reporter needs but {@code core} can't discover on its own (it
+ * has no Minecraft on its classpath). Each loader builds this from its own APIs and hands it to
+ * {@link CrashReporting#bootstrap}, keeping {@code core} free of any {@code net.minecraft.*} types.
+ *
+ * @param modVersion the running mod version, e.g. {@code 2.2.0+mc26.1.2.fabric} or {@code 0.0.0-dev}
+ * @param loaderName {@code "fabric"} or {@code "neoforge"}
+ * @param minecraftVersion the Minecraft version, e.g. {@code 26.1.2}
+ * @param developmentEnvironment true in a dev/runClient session, false in a shipped build
+ */
+public record PlatformInfo(
+        String modVersion, String loaderName, String minecraftVersion, boolean developmentEnvironment) {}

--- a/core/src/test/java/com/indemnity83/irontanks/core/crash/CrashReportingTest.java
+++ b/core/src/test/java/com/indemnity83/irontanks/core/crash/CrashReportingTest.java
@@ -1,0 +1,156 @@
+package com.indemnity83.irontanks.core.crash;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.sentry.ISentryClient;
+import java.lang.reflect.Proxy;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class CrashReportingTest {
+
+    private FakeClient fake;
+    private Path configFile;
+
+    @BeforeEach
+    void setUp(@TempDir Path dir) {
+        configFile = dir.resolve("irontanks.json");
+        fake = new FakeClient();
+        CrashReporting.resetForTesting(options -> fake.client);
+    }
+
+    @AfterEach
+    void tearDown() {
+        CrashReporting.resetForTesting(null);
+    }
+
+    private static PlatformInfo platform() {
+        return new PlatformInfo("1.2.3+test", "fabric", "26.1.2", false);
+    }
+
+    @Test
+    void disabledByDefaultDropsCaptures() {
+        CrashReporting.bootstrap(platform(), configFile, null);
+
+        assertThat(CrashReporting.isActive()).isFalse();
+        CrashReporting.capture(new RuntimeException("ignored"));
+        assertThat(fake.captured).isEmpty();
+    }
+
+    @Test
+    void enableActivatesPersistsAndForwards() {
+        CrashReporting.bootstrap(platform(), configFile, null);
+
+        assertThat(CrashReporting.enable()).isTrue();
+        assertThat(CrashReporting.isActive()).isTrue();
+        assertThat(IronTanksConfig.load(configFile).crashReporting().enabled()).isTrue();
+
+        CrashReporting.capture(new RuntimeException("boom"));
+        assertThat(fake.captured).hasSize(1);
+    }
+
+    @Test
+    void disableDeactivatesPersistsAndCloses() {
+        CrashReporting.bootstrap(platform(), configFile, null);
+        CrashReporting.enable();
+
+        CrashReporting.disable();
+
+        assertThat(CrashReporting.isActive()).isFalse();
+        assertThat(fake.closed).isTrue();
+        assertThat(IronTanksConfig.load(configFile).crashReporting().enabled()).isFalse();
+
+        CrashReporting.capture(new RuntimeException("dropped"));
+        assertThat(fake.captured).isEmpty();
+    }
+
+    @Test
+    void bootstrapComesUpActiveWhenConfigEnabled() {
+        IronTanksConfig pre = IronTanksConfig.load(configFile);
+        pre.crashReporting().setEnabled(true);
+        pre.save(configFile);
+
+        CrashReporting.bootstrap(platform(), configFile, null);
+
+        assertThat(CrashReporting.isActive()).isTrue();
+    }
+
+    @Test
+    void previewIsScrubbedAndNeverTouchesClient() {
+        CrashReporting.bootstrap(platform(), configFile, null);
+        CrashReporting.enable();
+
+        String preview = CrashReporting.previewReport();
+
+        assertThat(preview).contains("<uuid>").contains("<ip>").contains("<redacted>");
+        assertThat(preview).doesNotContain("550e8400").doesNotContain("203.0.113.7");
+        assertThat(fake.captured).isEmpty();
+        assertThat(CrashReporting.isActive()).isTrue();
+    }
+
+    @Test
+    void testReportRequiresActiveReporting() {
+        CrashReporting.bootstrap(platform(), configFile, null);
+
+        assertThat(CrashReporting.sendTestReport()).isFalse();
+
+        CrashReporting.enable();
+        assertThat(CrashReporting.sendTestReport()).isTrue();
+        assertThat(fake.captured).hasSize(1);
+    }
+
+    /**
+     * A recording stand-in for {@link ISentryClient}. The interface has many methods (most defaulted),
+     * so we implement it with a dynamic proxy and only react to the few calls the orchestrator makes —
+     * {@code captureException}, {@code flush}, {@code close}, {@code isEnabled}.
+     */
+    private static final class FakeClient {
+        private final List<Throwable> captured = new ArrayList<>();
+        private boolean closed;
+        private final ISentryClient client = (ISentryClient) Proxy.newProxyInstance(
+                ISentryClient.class.getClassLoader(), new Class<?>[] {ISentryClient.class}, (proxy, method, args) -> {
+                    String name = method.getName();
+                    if (name.equals("captureException") && args != null) {
+                        for (Object arg : args) {
+                            if (arg instanceof Throwable t) {
+                                captured.add(t);
+                                break;
+                            }
+                        }
+                        return null;
+                    }
+                    if (name.equals("close")) {
+                        closed = true;
+                        return null;
+                    }
+                    if (name.equals("isEnabled")) {
+                        return Boolean.TRUE;
+                    }
+                    if (name.equals("hashCode")) {
+                        return System.identityHashCode(proxy);
+                    }
+                    if (name.equals("equals")) {
+                        return proxy == (args == null ? null : args[0]);
+                    }
+                    if (name.equals("toString")) {
+                        return "FakeClient";
+                    }
+                    Class<?> rt = method.getReturnType();
+                    if (rt == boolean.class) {
+                        return false;
+                    }
+                    if (rt == int.class) {
+                        return 0;
+                    }
+                    if (rt == long.class) {
+                        return 0L;
+                    }
+                    return null;
+                });
+    }
+}

--- a/core/src/test/java/com/indemnity83/irontanks/core/crash/IronTanksConfigTest.java
+++ b/core/src/test/java/com/indemnity83/irontanks/core/crash/IronTanksConfigTest.java
@@ -1,0 +1,50 @@
+package com.indemnity83.irontanks.core.crash;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class IronTanksConfigTest {
+
+    @Test
+    void missingFileYieldsDefaultsAndWritesIt(@TempDir Path dir) throws Exception {
+        Path file = dir.resolve("irontanks.json");
+
+        IronTanksConfig config = IronTanksConfig.load(file);
+
+        assertThat(config.crashReporting().enabled()).isFalse();
+        assertThat(config.crashReporting().notifyOperators()).isTrue();
+        assertThat(config.crashReporting().dsnOverride()).isEmpty();
+        assertThat(Files.exists(file)).isTrue();
+    }
+
+    @Test
+    void roundTripsChangedValues(@TempDir Path dir) {
+        Path file = dir.resolve("irontanks.json");
+        IronTanksConfig config = IronTanksConfig.load(file);
+        config.crashReporting().setEnabled(true);
+        config.crashReporting().setNotifyOperators(false);
+        config.crashReporting().setDsnOverride("https://override@example.com/9");
+        config.save(file);
+
+        IronTanksConfig reloaded = IronTanksConfig.load(file);
+
+        assertThat(reloaded.crashReporting().enabled()).isTrue();
+        assertThat(reloaded.crashReporting().notifyOperators()).isFalse();
+        assertThat(reloaded.crashReporting().dsnOverride()).isEqualTo("https://override@example.com/9");
+    }
+
+    @Test
+    void corruptFileFallsBackToDefaults(@TempDir Path dir) throws Exception {
+        Path file = dir.resolve("irontanks.json");
+        Files.writeString(file, "{ this is not valid json ");
+
+        IronTanksConfig config = IronTanksConfig.load(file);
+
+        assertThat(config.crashReporting().enabled()).isFalse();
+        assertThat(config.crashReporting().notifyOperators()).isTrue();
+    }
+}

--- a/core/src/test/java/com/indemnity83/irontanks/core/crash/Log4j2BridgeTest.java
+++ b/core/src/test/java/com/indemnity83/irontanks/core/crash/Log4j2BridgeTest.java
@@ -1,0 +1,33 @@
+package com.indemnity83.irontanks.core.crash;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class Log4j2BridgeTest {
+
+    @Test
+    void forwardsIronTanksErrorsWithThrowable() {
+        assertThat(Log4j2Bridge.shouldForward("irontanks", true)).isTrue();
+        assertThat(Log4j2Bridge.shouldForward("irontanks/crash", true)).isTrue();
+        assertThat(Log4j2Bridge.shouldForward("com.indemnity83.irontanks.core.FluidColumn", true))
+                .isTrue();
+    }
+
+    @Test
+    void ignoresOtherLoggers() {
+        assertThat(Log4j2Bridge.shouldForward("net.minecraft.server.Main", true))
+                .isFalse();
+        assertThat(Log4j2Bridge.shouldForward("com.someothermod.Thing", true)).isFalse();
+    }
+
+    @Test
+    void ignoresEventsWithoutThrowable() {
+        assertThat(Log4j2Bridge.shouldForward("irontanks", false)).isFalse();
+    }
+
+    @Test
+    void ignoresNullLoggerName() {
+        assertThat(Log4j2Bridge.shouldForward(null, true)).isFalse();
+    }
+}

--- a/core/src/test/java/com/indemnity83/irontanks/core/crash/LogScrubberTest.java
+++ b/core/src/test/java/com/indemnity83/irontanks/core/crash/LogScrubberTest.java
@@ -1,0 +1,73 @@
+package com.indemnity83.irontanks.core.crash;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.sentry.SentryEvent;
+import io.sentry.protocol.Message;
+import io.sentry.protocol.SentryException;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class LogScrubberTest {
+
+    @Test
+    void redactsGenericHomeDirectories() {
+        assertThat(LogScrubber.redact("saving /Users/alice/world")).isEqualTo("saving /Users/<user>/world");
+        assertThat(LogScrubber.redact("saving /home/bob/world")).isEqualTo("saving /home/<user>/world");
+        assertThat(LogScrubber.redact("at C:\\Users\\carol\\saves")).isEqualTo("at C:\\Users\\<user>\\saves");
+    }
+
+    @Test
+    void redactsUuidsAndIpAddresses() {
+        assertThat(LogScrubber.redact("player 550e8400-e29b-41d4-a716-446655440000 joined"))
+                .isEqualTo("player <uuid> joined");
+        assertThat(LogScrubber.redact("from 203.0.113.7 now")).isEqualTo("from <ip> now");
+    }
+
+    @Test
+    void redactsSecretLikeKeyValues() {
+        assertThat(LogScrubber.redact("token=s3cr3t-abc")).isEqualTo("token=<redacted>");
+        assertThat(LogScrubber.redact("password: hunter2")).isEqualTo("password: <redacted>");
+        assertThat(LogScrubber.redact("api_key = ABC123")).isEqualTo("api_key = <redacted>");
+        assertThat(LogScrubber.redact("dsn=https://abc@example.com/1")).isEqualTo("dsn=<redacted>");
+    }
+
+    @Test
+    void leavesOrdinaryTextUntouched() {
+        String safe = "Tank column at 12, 64, -8 settled 16000 mB of water";
+        assertThat(LogScrubber.redact(safe)).isEqualTo(safe);
+    }
+
+    @Test
+    void isIdempotent() {
+        String once = LogScrubber.redact("u 550e8400-e29b-41d4-a716-446655440000 ip 203.0.113.7 token=abc");
+        assertThat(LogScrubber.redact(once)).isEqualTo(once);
+    }
+
+    @Test
+    void handlesNullAndEmpty() {
+        assertThat(LogScrubber.redact(null)).isNull();
+        assertThat(LogScrubber.redact("")).isEmpty();
+    }
+
+    @Test
+    void scrubsMessageExceptionAndDropsServerName() {
+        SentryEvent event = new SentryEvent();
+        event.setServerName("my-secret-host");
+        Message message = new Message();
+        message.setMessage("crash for 550e8400-e29b-41d4-a716-446655440000 from 203.0.113.7");
+        message.setFormatted(message.getMessage());
+        event.setMessage(message);
+        SentryException exception = new SentryException();
+        exception.setValue("failed at /home/dave/world with token=abc123");
+        event.setExceptions(List.of(exception));
+
+        LogScrubber.scrub(event);
+
+        assertThat(event.getServerName()).isNull();
+        assertThat(event.getMessage().getMessage()).isEqualTo("crash for <uuid> from <ip>");
+        assertThat(event.getMessage().getFormatted()).isEqualTo("crash for <uuid> from <ip>");
+        assertThat(event.getExceptions().get(0).getValue())
+                .isEqualTo("failed at /home/<user>/world with token=<redacted>");
+    }
+}

--- a/core/src/test/java/com/indemnity83/irontanks/core/crash/LogScrubberTest.java
+++ b/core/src/test/java/com/indemnity83/irontanks/core/crash/LogScrubberTest.java
@@ -45,6 +45,24 @@ class LogScrubberTest {
     }
 
     @Test
+    void redactsWholeWordUsernameButNotEmbeddedOrShortMatches() {
+        String original = System.getProperty("user.name");
+        try {
+            System.setProperty("user.name", "root");
+            assertThat(LogScrubber.redact("logged in as root")).isEqualTo("logged in as <user>");
+            assertThat(LogScrubber.redact("rootCause: boom")).isEqualTo("rootCause: boom");
+
+            // Names shorter than 3 chars are too collision-prone to replace at all.
+            System.setProperty("user.name", "mc");
+            assertThat(LogScrubber.redact("running as mc on mcServer")).isEqualTo("running as mc on mcServer");
+        } finally {
+            if (original != null) {
+                System.setProperty("user.name", original);
+            }
+        }
+    }
+
+    @Test
     void handlesNullAndEmpty() {
         assertThat(LogScrubber.redact(null)).isNull();
         assertThat(LogScrubber.redact("")).isEmpty();

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -3,6 +3,7 @@
 plugins {
     id 'java-library'
     id 'net.fabricmc.fabric-loom'
+    id 'io.sentry.jvm.gradle'
 }
 
 // Fabric is lenient about versions, but keep parity with the NeoForge module's dev version.
@@ -36,6 +37,12 @@ dependencies {
     implementation "net.fabricmc:fabric-loader:${rootProject.fabric_loader_version}"
     implementation "net.fabricmc.fabric-api:fabric-api:${rootProject.fabric_version}"
     implementation project(':core')
+
+    // Sentry crash-reporting SDK. core uses it but doesn't bundle it (its dep is compileOnly), so the
+    // loader supplies it: implementation puts it on the dev runtime classpath, include nests it
+    // jar-in-jar for shipped builds. Gson/Log4j2 that core also needs are provided by Minecraft.
+    implementation "io.sentry:sentry:${rootProject.sentry_version}"
+    include "io.sentry:sentry:${rootProject.sentry_version}"
 }
 
 // Embed the pure-logic core classes directly into the mod jar.
@@ -69,4 +76,27 @@ processResources {
 
 tasks.withType(JavaCompile).configureEach {
     it.options.release = rootProject.java_version.toInteger()
+}
+
+// Sentry source-context upload (so stack traces show inline source in Sentry). Gated on the
+// SENTRY_AUTH_TOKEN secret: local/PR builds without it skip the upload entirely and never fail.
+// We manage the SDK dependency ourselves above, so the plugin's auto-install/telemetry stay off.
+def sentryAuthToken = System.getenv("SENTRY_AUTH_TOKEN")
+sentry {
+    includeSourceContext = sentryAuthToken != null && !sentryAuthToken.isEmpty()
+    org = "indmenity83"
+    projectName = "irontanks-mod"
+    authToken = sentryAuthToken
+    autoInstallation {
+        enabled = false
+    }
+    telemetry = false
+}
+
+// The Sentry plugin emits generated metadata into the main resources, which withSourcesJar() also
+// picks up; declare the dependency so Gradle 9 doesn't reject the implicit one on `build`.
+tasks.named('sourcesJar') {
+    dependsOn(tasks.matching {
+        it.name.toLowerCase().startsWith('generatesentry') || it.name == 'collectExternalDependenciesForSentry'
+    })
 }

--- a/fabric/src/main/java/com/indemnity83/irontanks/fabric/IronTanksFabric.java
+++ b/fabric/src/main/java/com/indemnity83/irontanks/fabric/IronTanksFabric.java
@@ -2,6 +2,7 @@ package com.indemnity83.irontanks.fabric;
 
 import com.indemnity83.irontanks.fabric.content.IronTanksContent;
 import com.indemnity83.irontanks.fabric.content.TankFluidStorage;
+import com.indemnity83.irontanks.fabric.crash.CrashReportingBootstrap;
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.transfer.v1.fluid.FluidStorage;
 import org.slf4j.Logger;
@@ -25,5 +26,8 @@ public final class IronTanksFabric implements ModInitializer {
         // Expose every tank's fluid storage so pipes/pumps can fill and drain it.
         FluidStorage.SIDED.registerForBlockEntity(
                 (tank, direction) -> new TankFluidStorage(tank), IronTanksContent.TANK_BLOCK_ENTITY);
+
+        // Opt-in (default off) sanitized crash reporting.
+        CrashReportingBootstrap.init();
     }
 }

--- a/fabric/src/main/java/com/indemnity83/irontanks/fabric/crash/CrashReportNotifier.java
+++ b/fabric/src/main/java/com/indemnity83/irontanks/fabric/crash/CrashReportNotifier.java
@@ -1,0 +1,91 @@
+package com.indemnity83.irontanks.fabric.crash;
+
+import com.indemnity83.irontanks.core.crash.CrashReporting;
+import java.net.URI;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import net.minecraft.ChatFormatting;
+import net.minecraft.commands.Commands;
+import net.minecraft.network.chat.ClickEvent;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.HoverEvent;
+import net.minecraft.server.level.ServerPlayer;
+
+/**
+ * Shows operators a once-per-session crash-reporting status line on join (unless they've silenced
+ * it), with clickable toggles and a link to the privacy page. The per-session dedup resets on
+ * server start so each session shows it again.
+ */
+public final class CrashReportNotifier {
+
+    private CrashReportNotifier() {}
+
+    private static final Set<UUID> NOTIFIED_THIS_SESSION = ConcurrentHashMap.newKeySet();
+
+    private static final String DETAILS_URL =
+            "https://github.com/Indemnity83/irontanks/blob/mc/26.1/CRASH_REPORTING.md";
+    private static final String ENABLE_COMMAND = "/irontanks diagnostics enable";
+    private static final String DISABLE_COMMAND = "/irontanks diagnostics disable";
+    private static final String HIDE_COMMAND = "/irontanks diagnostics notify off";
+
+    /** Clear the per-session dedup so the next server session shows the notice again. */
+    public static void reset() {
+        NOTIFIED_THIS_SESSION.clear();
+    }
+
+    /** Show the once-per-session status line to operators who haven't silenced it. */
+    public static void maybeNotify(ServerPlayer player) {
+        if (!CrashReporting.notifyOperators() || !isOperator(player)) {
+            return;
+        }
+        if (NOTIFIED_THIS_SESSION.add(player.getUUID())) {
+            player.sendSystemMessage(invite(CrashReporting.isEnabled()));
+        }
+    }
+
+    private static boolean isOperator(ServerPlayer player) {
+        return Commands.LEVEL_GAMEMASTERS.check(player.permissions());
+    }
+
+    private static Component invite(boolean enabled) {
+        return Component.empty()
+                .append(Component.literal("[Iron Tanks] ").withStyle(ChatFormatting.AQUA))
+                .append(Component.literal("Crash reporting is ").withStyle(ChatFormatting.GRAY))
+                .append(toggle(enabled))
+                .append(Component.literal("  "))
+                .append(link(
+                        "[hide]",
+                        ChatFormatting.DARK_GRAY,
+                        "Stop showing this notice",
+                        new ClickEvent.RunCommand(HIDE_COMMAND)))
+                .append(Component.literal("  "))
+                .append(link(
+                        "[More Info]",
+                        ChatFormatting.BLUE,
+                        "Open the crash-reporting & privacy page",
+                        new ClickEvent.OpenUrl(URI.create(DETAILS_URL))));
+    }
+
+    private static Component toggle(boolean enabled) {
+        if (enabled) {
+            return link(
+                    "[ON]",
+                    ChatFormatting.GREEN,
+                    "Click to turn crash reporting off",
+                    new ClickEvent.RunCommand(DISABLE_COMMAND));
+        }
+        return link(
+                "[OFF]",
+                ChatFormatting.RED,
+                "Click to turn on sanitized crash reporting",
+                new ClickEvent.RunCommand(ENABLE_COMMAND));
+    }
+
+    private static Component link(String label, ChatFormatting color, String hover, ClickEvent click) {
+        return Component.literal(label)
+                .withStyle(style -> style.withColor(color)
+                        .withClickEvent(click)
+                        .withHoverEvent(new HoverEvent.ShowText(Component.literal(hover))));
+    }
+}

--- a/fabric/src/main/java/com/indemnity83/irontanks/fabric/crash/CrashReportNotifier.java
+++ b/fabric/src/main/java/com/indemnity83/irontanks/fabric/crash/CrashReportNotifier.java
@@ -40,7 +40,7 @@ public final class CrashReportNotifier {
             return;
         }
         if (NOTIFIED_THIS_SESSION.add(player.getUUID())) {
-            player.sendSystemMessage(invite(CrashReporting.isEnabled()));
+            player.sendSystemMessage(invite(CrashReporting.isActive()));
         }
     }
 

--- a/fabric/src/main/java/com/indemnity83/irontanks/fabric/crash/CrashReportingBootstrap.java
+++ b/fabric/src/main/java/com/indemnity83/irontanks/fabric/crash/CrashReportingBootstrap.java
@@ -30,7 +30,7 @@ public final class CrashReportingBootstrap {
             ServerPlayConnectionEvents.JOIN.register(
                     (handler, sender, server) -> CrashReportNotifier.maybeNotify(handler.player));
         } catch (Throwable t) {
-            LOGGER.warn("Could not initialize crash reporting: {}", t.toString());
+            LOGGER.warn("Could not initialize crash reporting", t);
         }
     }
 }

--- a/fabric/src/main/java/com/indemnity83/irontanks/fabric/crash/CrashReportingBootstrap.java
+++ b/fabric/src/main/java/com/indemnity83/irontanks/fabric/crash/CrashReportingBootstrap.java
@@ -1,0 +1,36 @@
+package com.indemnity83.irontanks.fabric.crash;
+
+import com.indemnity83.irontanks.core.crash.CrashReporting;
+import com.indemnity83.irontanks.core.crash.PlatformInfo;
+import java.nio.file.Path;
+import net.fabricmc.fabric.api.command.v2.CommandRegistrationCallback;
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
+import net.fabricmc.fabric.api.networking.v1.ServerPlayConnectionEvents;
+import net.fabricmc.loader.api.FabricLoader;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Wires opt-in crash reporting into the Fabric lifecycle: bootstrap, command, join notice. */
+public final class CrashReportingBootstrap {
+
+    private CrashReportingBootstrap() {}
+
+    private static final Logger LOGGER = LoggerFactory.getLogger("irontanks/crash");
+
+    /** Best-effort init — a failure here logs a warning and never breaks mod load. */
+    public static void init() {
+        try {
+            PlatformInfo platform = FabricPlatformInfo.create();
+            Path configFile = FabricLoader.getInstance().getConfigDir().resolve("irontanks.json");
+            CrashReporting.bootstrap(platform, configFile, CrashReporting.DEFAULT_DSN);
+
+            CommandRegistrationCallback.EVENT.register((dispatcher, registryAccess, environment) ->
+                    IronTanksDiagnosticsCommand.register(dispatcher, platform.developmentEnvironment()));
+            ServerLifecycleEvents.SERVER_STARTING.register(server -> CrashReportNotifier.reset());
+            ServerPlayConnectionEvents.JOIN.register(
+                    (handler, sender, server) -> CrashReportNotifier.maybeNotify(handler.player));
+        } catch (Throwable t) {
+            LOGGER.warn("Could not initialize crash reporting: {}", t.toString());
+        }
+    }
+}

--- a/fabric/src/main/java/com/indemnity83/irontanks/fabric/crash/FabricPlatformInfo.java
+++ b/fabric/src/main/java/com/indemnity83/irontanks/fabric/crash/FabricPlatformInfo.java
@@ -1,0 +1,21 @@
+package com.indemnity83.irontanks.fabric.crash;
+
+import com.indemnity83.irontanks.core.crash.PlatformInfo;
+import net.fabricmc.loader.api.FabricLoader;
+
+/** Builds the loader-agnostic {@link PlatformInfo} the crash reporter needs from Fabric's APIs. */
+public final class FabricPlatformInfo {
+
+    private FabricPlatformInfo() {}
+
+    public static PlatformInfo create() {
+        FabricLoader loader = FabricLoader.getInstance();
+        String modVersion = loader.getModContainer("irontanks")
+                .map(container -> container.getMetadata().getVersion().getFriendlyString())
+                .orElse("0.0.0-dev");
+        String minecraftVersion = loader.getModContainer("minecraft")
+                .map(container -> container.getMetadata().getVersion().getFriendlyString())
+                .orElse("unknown");
+        return new PlatformInfo(modVersion, "fabric", minecraftVersion, loader.isDevelopmentEnvironment());
+    }
+}

--- a/fabric/src/main/java/com/indemnity83/irontanks/fabric/crash/IronTanksDiagnosticsCommand.java
+++ b/fabric/src/main/java/com/indemnity83/irontanks/fabric/crash/IronTanksDiagnosticsCommand.java
@@ -1,0 +1,97 @@
+package com.indemnity83.irontanks.fabric.crash;
+
+import com.indemnity83.irontanks.core.crash.CrashReporting;
+import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.builder.LiteralArgumentBuilder;
+import net.minecraft.ChatFormatting;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.commands.Commands;
+import net.minecraft.network.chat.Component;
+
+/**
+ * The {@code /irontanks diagnostics} command tree: status, enable, disable, preview, and the
+ * operator join-notice toggle. A dev-only {@code test} subcommand sends a synthetic report so the
+ * pipeline can be verified by hand. Operator-only ({@link Commands#LEVEL_GAMEMASTERS}).
+ */
+public final class IronTanksDiagnosticsCommand {
+
+    private IronTanksDiagnosticsCommand() {}
+
+    public static void register(CommandDispatcher<CommandSourceStack> dispatcher, boolean development) {
+        LiteralArgumentBuilder<CommandSourceStack> diagnostics = Commands.literal("diagnostics")
+                .requires(Commands.hasPermission(Commands.LEVEL_GAMEMASTERS))
+                .executes(ctx -> {
+                    ctx.getSource().sendSuccess(IronTanksDiagnosticsCommand::status, false);
+                    return 1;
+                })
+                .then(Commands.literal("enable").executes(ctx -> {
+                    if (CrashReporting.enable()) {
+                        ctx.getSource()
+                                .sendSuccess(
+                                        () -> Component.literal(
+                                                        "Sanitized crash reporting enabled. Thanks for helping improve Iron Tanks!")
+                                                .withStyle(ChatFormatting.GREEN),
+                                        true);
+                        return 1;
+                    }
+                    ctx.getSource()
+                            .sendFailure(
+                                    Component.literal(
+                                            "Could not start crash reporting — no DSN configured or initialization failed. See the log."));
+                    return 0;
+                }))
+                .then(Commands.literal("disable").executes(ctx -> {
+                    CrashReporting.disable();
+                    ctx.getSource()
+                            .sendSuccess(
+                                    () -> Component.literal("Crash reporting disabled.")
+                                            .withStyle(ChatFormatting.YELLOW),
+                                    true);
+                    return 1;
+                }))
+                .then(Commands.literal("preview").executes(ctx -> {
+                    ctx.getSource().sendSuccess(() -> Component.literal(CrashReporting.previewReport()), false);
+                    return 1;
+                }))
+                .then(Commands.literal("notify")
+                        .then(Commands.literal("on").executes(ctx -> {
+                            CrashReporting.setNotifyOperators(true);
+                            ctx.getSource()
+                                    .sendSuccess(
+                                            () -> Component.literal("Join-time crash-reporting notice enabled."), true);
+                            return 1;
+                        }))
+                        .then(Commands.literal("off").executes(ctx -> {
+                            CrashReporting.setNotifyOperators(false);
+                            ctx.getSource()
+                                    .sendSuccess(
+                                            () -> Component.literal("Join-time crash-reporting notice disabled."),
+                                            true);
+                            return 1;
+                        })));
+
+        if (development) {
+            diagnostics.then(Commands.literal("test").executes(ctx -> {
+                if (CrashReporting.sendTestReport()) {
+                    ctx.getSource().sendSuccess(() -> Component.literal("Sent a test crash report to Sentry."), false);
+                    return 1;
+                }
+                ctx.getSource()
+                        .sendFailure(Component.literal(
+                                "Crash reporting is not active. Run /irontanks diagnostics enable first."));
+                return 0;
+            }));
+        }
+
+        dispatcher.register(Commands.literal("irontanks").then(diagnostics));
+    }
+
+    private static Component status() {
+        boolean active = CrashReporting.isActive();
+        return Component.literal("[Iron Tanks] ")
+                .withStyle(ChatFormatting.AQUA)
+                .append(Component.literal("Crash reporting is ").withStyle(ChatFormatting.GRAY))
+                .append(Component.literal(active ? "ON" : "OFF")
+                        .withStyle(active ? ChatFormatting.GREEN : ChatFormatting.RED));
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -29,6 +29,15 @@ neoforge_loader_version_range=[4,)
 neo_form_version=26.1.2-1
 moddev_version=2.0.141
 
+# Crash reporting (Sentry). sentry_version = runtime SDK (bundled per loader); sentry_gradle_version =
+# the io.sentry.jvm.gradle source-context plugin. gson/log4j are provided by Minecraft at runtime —
+# pinned here only so core compiles/tests against the same versions MC 26.1 ships.
+sentry_version=8.16.0
+sentry_gradle_version=5.8.0
+gson_version=2.13.2
+log4j_version=2.25.2
+slf4j_version=2.0.17
+
 # Test Dependencies
 junit_version=5.11.0
 assertj_version=3.26.0

--- a/neoforge/build.gradle
+++ b/neoforge/build.gradle
@@ -3,6 +3,7 @@
 plugins {
     id 'java-library'
     id 'net.neoforged.moddev'
+    id 'io.sentry.jvm.gradle'
 }
 
 // NeoForge requires a valid Maven/SemVer version in neoforge.mods.toml; the root's "dev-local" marker
@@ -24,6 +25,17 @@ repositories {
 
 dependencies {
     implementation project(':core')
+
+    // Sentry crash-reporting SDK. core uses it but doesn't bundle it (its dep is compileOnly), so the
+    // loader supplies it: implementation puts it on the dev runtime classpath, jarJar nests it
+    // jar-in-jar for shipped builds. The version range lets JarJar dedupe against any copy another mod
+    // ships while preferring our pinned version. Gson/Log4j2 that core also needs come from Minecraft.
+    jarJar(implementation("io.sentry:sentry")) {
+        version {
+            strictly "[${rootProject.sentry_version},9.0.0)"
+            prefer "${rootProject.sentry_version}"
+        }
+    }
 }
 
 neoForge {
@@ -76,4 +88,27 @@ processResources {
 
 tasks.withType(JavaCompile).configureEach {
     it.options.release = rootProject.java_version.toInteger()
+}
+
+// Sentry source-context upload (so stack traces show inline source in Sentry). Gated on the
+// SENTRY_AUTH_TOKEN secret: local/PR builds without it skip the upload entirely and never fail.
+// We manage the SDK dependency ourselves above, so the plugin's auto-install/telemetry stay off.
+def sentryAuthToken = System.getenv("SENTRY_AUTH_TOKEN")
+sentry {
+    includeSourceContext = sentryAuthToken != null && !sentryAuthToken.isEmpty()
+    org = "indmenity83"
+    projectName = "irontanks-mod"
+    authToken = sentryAuthToken
+    autoInstallation {
+        enabled = false
+    }
+    telemetry = false
+}
+
+// The Sentry plugin emits generated metadata into the main resources, which withSourcesJar() also
+// picks up; declare the dependency so Gradle 9 doesn't reject the implicit one on `build`.
+tasks.named('sourcesJar') {
+    dependsOn(tasks.matching {
+        it.name.toLowerCase().startsWith('generatesentry') || it.name == 'collectExternalDependenciesForSentry'
+    })
 }

--- a/neoforge/src/main/java/com/indemnity83/irontanks/neoforge/IronTanksNeoForge.java
+++ b/neoforge/src/main/java/com/indemnity83/irontanks/neoforge/IronTanksNeoForge.java
@@ -2,6 +2,7 @@ package com.indemnity83.irontanks.neoforge;
 
 import com.indemnity83.irontanks.neoforge.client.IronTanksClient;
 import com.indemnity83.irontanks.neoforge.content.IronTanksContent;
+import com.indemnity83.irontanks.neoforge.crash.CrashReportingBootstrap;
 import net.neoforged.bus.api.IEventBus;
 import net.neoforged.fml.common.Mod;
 import net.neoforged.fml.loading.FMLEnvironment;
@@ -28,6 +29,9 @@ public final class IronTanksNeoForge {
         if (FMLEnvironment.getDist().isClient()) {
             IronTanksClient.register(modBus);
         }
+
+        // Opt-in (default off) sanitized crash reporting.
+        CrashReportingBootstrap.init();
     }
 
     private synchronized void onRegister(RegisterEvent event) {

--- a/neoforge/src/main/java/com/indemnity83/irontanks/neoforge/crash/CrashReportNotifier.java
+++ b/neoforge/src/main/java/com/indemnity83/irontanks/neoforge/crash/CrashReportNotifier.java
@@ -40,7 +40,7 @@ public final class CrashReportNotifier {
             return;
         }
         if (NOTIFIED_THIS_SESSION.add(player.getUUID())) {
-            player.sendSystemMessage(invite(CrashReporting.isEnabled()));
+            player.sendSystemMessage(invite(CrashReporting.isActive()));
         }
     }
 

--- a/neoforge/src/main/java/com/indemnity83/irontanks/neoforge/crash/CrashReportNotifier.java
+++ b/neoforge/src/main/java/com/indemnity83/irontanks/neoforge/crash/CrashReportNotifier.java
@@ -1,0 +1,91 @@
+package com.indemnity83.irontanks.neoforge.crash;
+
+import com.indemnity83.irontanks.core.crash.CrashReporting;
+import java.net.URI;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import net.minecraft.ChatFormatting;
+import net.minecraft.commands.Commands;
+import net.minecraft.network.chat.ClickEvent;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.HoverEvent;
+import net.minecraft.server.level.ServerPlayer;
+
+/**
+ * Shows operators a once-per-session crash-reporting status line on join (unless they've silenced
+ * it), with clickable toggles and a link to the privacy page. The per-session dedup resets on
+ * server start so each session shows it again.
+ */
+public final class CrashReportNotifier {
+
+    private CrashReportNotifier() {}
+
+    private static final Set<UUID> NOTIFIED_THIS_SESSION = ConcurrentHashMap.newKeySet();
+
+    private static final String DETAILS_URL =
+            "https://github.com/Indemnity83/irontanks/blob/mc/26.1/CRASH_REPORTING.md";
+    private static final String ENABLE_COMMAND = "/irontanks diagnostics enable";
+    private static final String DISABLE_COMMAND = "/irontanks diagnostics disable";
+    private static final String HIDE_COMMAND = "/irontanks diagnostics notify off";
+
+    /** Clear the per-session dedup so the next server session shows the notice again. */
+    public static void reset() {
+        NOTIFIED_THIS_SESSION.clear();
+    }
+
+    /** Show the once-per-session status line to operators who haven't silenced it. */
+    public static void maybeNotify(ServerPlayer player) {
+        if (!CrashReporting.notifyOperators() || !isOperator(player)) {
+            return;
+        }
+        if (NOTIFIED_THIS_SESSION.add(player.getUUID())) {
+            player.sendSystemMessage(invite(CrashReporting.isEnabled()));
+        }
+    }
+
+    private static boolean isOperator(ServerPlayer player) {
+        return Commands.LEVEL_GAMEMASTERS.check(player.permissions());
+    }
+
+    private static Component invite(boolean enabled) {
+        return Component.empty()
+                .append(Component.literal("[Iron Tanks] ").withStyle(ChatFormatting.AQUA))
+                .append(Component.literal("Crash reporting is ").withStyle(ChatFormatting.GRAY))
+                .append(toggle(enabled))
+                .append(Component.literal("  "))
+                .append(link(
+                        "[hide]",
+                        ChatFormatting.DARK_GRAY,
+                        "Stop showing this notice",
+                        new ClickEvent.RunCommand(HIDE_COMMAND)))
+                .append(Component.literal("  "))
+                .append(link(
+                        "[More Info]",
+                        ChatFormatting.BLUE,
+                        "Open the crash-reporting & privacy page",
+                        new ClickEvent.OpenUrl(URI.create(DETAILS_URL))));
+    }
+
+    private static Component toggle(boolean enabled) {
+        if (enabled) {
+            return link(
+                    "[ON]",
+                    ChatFormatting.GREEN,
+                    "Click to turn crash reporting off",
+                    new ClickEvent.RunCommand(DISABLE_COMMAND));
+        }
+        return link(
+                "[OFF]",
+                ChatFormatting.RED,
+                "Click to turn on sanitized crash reporting",
+                new ClickEvent.RunCommand(ENABLE_COMMAND));
+    }
+
+    private static Component link(String label, ChatFormatting color, String hover, ClickEvent click) {
+        return Component.literal(label)
+                .withStyle(style -> style.withColor(color)
+                        .withClickEvent(click)
+                        .withHoverEvent(new HoverEvent.ShowText(Component.literal(hover))));
+    }
+}

--- a/neoforge/src/main/java/com/indemnity83/irontanks/neoforge/crash/CrashReportingBootstrap.java
+++ b/neoforge/src/main/java/com/indemnity83/irontanks/neoforge/crash/CrashReportingBootstrap.java
@@ -37,7 +37,7 @@ public final class CrashReportingBootstrap {
                 }
             });
         } catch (Throwable t) {
-            LOGGER.warn("Could not initialize crash reporting: {}", t.toString());
+            LOGGER.warn("Could not initialize crash reporting", t);
         }
     }
 }

--- a/neoforge/src/main/java/com/indemnity83/irontanks/neoforge/crash/CrashReportingBootstrap.java
+++ b/neoforge/src/main/java/com/indemnity83/irontanks/neoforge/crash/CrashReportingBootstrap.java
@@ -1,0 +1,43 @@
+package com.indemnity83.irontanks.neoforge.crash;
+
+import com.indemnity83.irontanks.core.crash.CrashReporting;
+import com.indemnity83.irontanks.core.crash.PlatformInfo;
+import java.nio.file.Path;
+import net.minecraft.server.level.ServerPlayer;
+import net.neoforged.bus.api.IEventBus;
+import net.neoforged.fml.loading.FMLPaths;
+import net.neoforged.neoforge.common.NeoForge;
+import net.neoforged.neoforge.event.RegisterCommandsEvent;
+import net.neoforged.neoforge.event.entity.player.PlayerEvent;
+import net.neoforged.neoforge.event.server.ServerStartingEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Wires opt-in crash reporting into the NeoForge lifecycle: bootstrap, command, join notice. */
+public final class CrashReportingBootstrap {
+
+    private CrashReportingBootstrap() {}
+
+    private static final Logger LOGGER = LoggerFactory.getLogger("irontanks/crash");
+
+    /** Best-effort init — a failure here logs a warning and never breaks mod load. */
+    public static void init() {
+        try {
+            PlatformInfo platform = NeoForgePlatformInfo.create();
+            Path configFile = FMLPaths.CONFIGDIR.get().resolve("irontanks.json");
+            CrashReporting.bootstrap(platform, configFile, CrashReporting.DEFAULT_DSN);
+
+            IEventBus gameBus = NeoForge.EVENT_BUS;
+            gameBus.addListener((RegisterCommandsEvent event) ->
+                    IronTanksDiagnosticsCommand.register(event.getDispatcher(), platform.developmentEnvironment()));
+            gameBus.addListener((ServerStartingEvent event) -> CrashReportNotifier.reset());
+            gameBus.addListener((PlayerEvent.PlayerLoggedInEvent event) -> {
+                if (event.getEntity() instanceof ServerPlayer player) {
+                    CrashReportNotifier.maybeNotify(player);
+                }
+            });
+        } catch (Throwable t) {
+            LOGGER.warn("Could not initialize crash reporting: {}", t.toString());
+        }
+    }
+}

--- a/neoforge/src/main/java/com/indemnity83/irontanks/neoforge/crash/IronTanksDiagnosticsCommand.java
+++ b/neoforge/src/main/java/com/indemnity83/irontanks/neoforge/crash/IronTanksDiagnosticsCommand.java
@@ -1,0 +1,97 @@
+package com.indemnity83.irontanks.neoforge.crash;
+
+import com.indemnity83.irontanks.core.crash.CrashReporting;
+import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.builder.LiteralArgumentBuilder;
+import net.minecraft.ChatFormatting;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.commands.Commands;
+import net.minecraft.network.chat.Component;
+
+/**
+ * The {@code /irontanks diagnostics} command tree: status, enable, disable, preview, and the
+ * operator join-notice toggle. A dev-only {@code test} subcommand sends a synthetic report so the
+ * pipeline can be verified by hand. Operator-only ({@link Commands#LEVEL_GAMEMASTERS}).
+ */
+public final class IronTanksDiagnosticsCommand {
+
+    private IronTanksDiagnosticsCommand() {}
+
+    public static void register(CommandDispatcher<CommandSourceStack> dispatcher, boolean development) {
+        LiteralArgumentBuilder<CommandSourceStack> diagnostics = Commands.literal("diagnostics")
+                .requires(Commands.hasPermission(Commands.LEVEL_GAMEMASTERS))
+                .executes(ctx -> {
+                    ctx.getSource().sendSuccess(IronTanksDiagnosticsCommand::status, false);
+                    return 1;
+                })
+                .then(Commands.literal("enable").executes(ctx -> {
+                    if (CrashReporting.enable()) {
+                        ctx.getSource()
+                                .sendSuccess(
+                                        () -> Component.literal(
+                                                        "Sanitized crash reporting enabled. Thanks for helping improve Iron Tanks!")
+                                                .withStyle(ChatFormatting.GREEN),
+                                        true);
+                        return 1;
+                    }
+                    ctx.getSource()
+                            .sendFailure(
+                                    Component.literal(
+                                            "Could not start crash reporting — no DSN configured or initialization failed. See the log."));
+                    return 0;
+                }))
+                .then(Commands.literal("disable").executes(ctx -> {
+                    CrashReporting.disable();
+                    ctx.getSource()
+                            .sendSuccess(
+                                    () -> Component.literal("Crash reporting disabled.")
+                                            .withStyle(ChatFormatting.YELLOW),
+                                    true);
+                    return 1;
+                }))
+                .then(Commands.literal("preview").executes(ctx -> {
+                    ctx.getSource().sendSuccess(() -> Component.literal(CrashReporting.previewReport()), false);
+                    return 1;
+                }))
+                .then(Commands.literal("notify")
+                        .then(Commands.literal("on").executes(ctx -> {
+                            CrashReporting.setNotifyOperators(true);
+                            ctx.getSource()
+                                    .sendSuccess(
+                                            () -> Component.literal("Join-time crash-reporting notice enabled."), true);
+                            return 1;
+                        }))
+                        .then(Commands.literal("off").executes(ctx -> {
+                            CrashReporting.setNotifyOperators(false);
+                            ctx.getSource()
+                                    .sendSuccess(
+                                            () -> Component.literal("Join-time crash-reporting notice disabled."),
+                                            true);
+                            return 1;
+                        })));
+
+        if (development) {
+            diagnostics.then(Commands.literal("test").executes(ctx -> {
+                if (CrashReporting.sendTestReport()) {
+                    ctx.getSource().sendSuccess(() -> Component.literal("Sent a test crash report to Sentry."), false);
+                    return 1;
+                }
+                ctx.getSource()
+                        .sendFailure(Component.literal(
+                                "Crash reporting is not active. Run /irontanks diagnostics enable first."));
+                return 0;
+            }));
+        }
+
+        dispatcher.register(Commands.literal("irontanks").then(diagnostics));
+    }
+
+    private static Component status() {
+        boolean active = CrashReporting.isActive();
+        return Component.literal("[Iron Tanks] ")
+                .withStyle(ChatFormatting.AQUA)
+                .append(Component.literal("Crash reporting is ").withStyle(ChatFormatting.GRAY))
+                .append(Component.literal(active ? "ON" : "OFF")
+                        .withStyle(active ? ChatFormatting.GREEN : ChatFormatting.RED));
+    }
+}

--- a/neoforge/src/main/java/com/indemnity83/irontanks/neoforge/crash/NeoForgePlatformInfo.java
+++ b/neoforge/src/main/java/com/indemnity83/irontanks/neoforge/crash/NeoForgePlatformInfo.java
@@ -1,0 +1,23 @@
+package com.indemnity83.irontanks.neoforge.crash;
+
+import com.indemnity83.irontanks.core.crash.PlatformInfo;
+import net.neoforged.fml.ModList;
+import net.neoforged.fml.loading.FMLEnvironment;
+
+/** Builds the loader-agnostic {@link PlatformInfo} the crash reporter needs from NeoForge's APIs. */
+public final class NeoForgePlatformInfo {
+
+    private NeoForgePlatformInfo() {}
+
+    public static PlatformInfo create() {
+        String modVersion = ModList.get()
+                .getModContainerById("irontanks")
+                .map(container -> container.getModInfo().getVersion().toString())
+                .orElse("0.0.0-dev");
+        String minecraftVersion = ModList.get()
+                .getModContainerById("minecraft")
+                .map(container -> container.getModInfo().getVersion().toString())
+                .orElse("unknown");
+        return new PlatformInfo(modVersion, "neoforge", minecraftVersion, !FMLEnvironment.isProduction());
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -15,6 +15,7 @@ pluginManagement {
         id 'net.fabricmc.fabric-loom' version "${loom_version}"
         id 'net.neoforged.moddev' version "${moddev_version}"
         id 'com.diffplug.spotless' version "${spotless_version}"
+        id 'io.sentry.jvm.gradle' version "${sentry_gradle_version}"
     }
 }
 


### PR DESCRIPTION
## Summary

Iron Tanks can now send **sanitized crash reports** so we catch and fix bugs players hit in the wild — without collecting any personal information. It's **opt-in and off by default**: nothing is ever sent until a server operator turns it on.

## Changes

### Added
- **Opt-in crash reporting** (powered by Sentry). Turn it on/off in-game with `/irontanks diagnostics enable` / `disable` — your choice persists in `config/irontanks.json`.
- **`/irontanks diagnostics` commands** (operator-only): show status, enable, disable, `preview` (prints exactly what a report looks like — nothing sent), and toggle the join-time notice.
- **Operator join notice**: a once-per-session, clickable reminder with `[ON]/[OFF]`, `[hide]`, and a `[More Info]` link — so server admins know reporting exists and can opt in or silence it.
- **Privacy scrubbing**: usernames, home paths, IPs, UUIDs, and secret-like `key=value` pairs are stripped before anything leaves your machine. Only Iron Tanks' own errors are captured — never another mod's or vanilla's.
- **`CRASH_REPORTING.md`** documenting what is and isn't collected, plus a README section.

## Notes

- **Default off** — fresh installs and players who never opt in send nothing.
- The bundled DSN is a public, write-only ingest key (safe to ship). Self-hosters can set `crashReporting.dsnOverride`.
- Iron Tanks uses its own dedicated Sentry client and never touches the global SDK, so it can't interfere with other mods that also use Sentry.

### Implementation
- Pure-Java reporting logic (orchestrator, scrubber, Log4j2 bridge, new Gson config) lives in `core` and is unit-tested (16 tests); only the Minecraft-typed command/notifier/event wiring is per-loader.
- Sentry SDK is bundled per loader (Fabric `include`, NeoForge `jarJar`); Gson/Log4j2 stay provided by Minecraft.
- CI: the `io.sentry.jvm.gradle` source-context plugin uploads inline source on release/snapshot/pre-release builds (gated on `SENTRY_AUTH_TOKEN`, so local/PR builds skip it), and `getsentry/action-release` registers a Sentry release per published jar for regression detection and deploy notifications.