### PR TITLE
ci: add Codecov coverage reporting for the core module

### DIFF
--- a/.github/workflows/check-code.yml
+++ b/.github/workflows/check-code.yml
@@ -49,7 +49,15 @@ jobs:
           cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
       - name: Run core tests
-        run: ./gradlew :core:test --console=plain
+        run: ./gradlew :core:jacocoTestReport --console=plain
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: core/build/reports/jacoco/test/jacocoTestReport.xml
+          flags: core
+          fail_ci_if_error: false
 
   # Smoke-build each loader jar (compile + assemble). Loaders have no test source set,
   # so a clean jar is their coverage. Only runs once lint + test pass.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,7 @@ toolchains, so changes do **not** cherry-pick between them — port by hand. Wit
 ```bash
 ./gradlew build                 # Build everything: core (+ unit tests), fabric, neoforge
 ./gradlew :core:test            # Run the pure-logic unit tests (no Minecraft, fast)
+./gradlew :core:jacocoTestReport # Run core tests + write the JaCoCo coverage report (XML for Codecov)
 ./gradlew :neoforge:runClient   # Launch the NeoForge dev client
 ./gradlew :fabric:runClient     # Launch the Fabric dev client
 ./gradlew :neoforge:jar         # Build just the NeoForge mod jar
@@ -145,7 +146,9 @@ than the source-injection / Architectury approaches; Iron Tanks is the testbed f
 - `VoidTank` — the 20 mB/tick self-destruction rate.
 - `TankUpgrade` — the upgrade graph (which tier promotes to which).
 
-`core` has JUnit tests and no MC dependency, so `./gradlew :core:test` runs instantly.
+`core` has JUnit tests and no MC dependency, so `./gradlew :core:test` runs instantly. It's the only
+module with a test source set; **JaCoCo** measures its coverage (`:core:jacocoTestReport`, pinned to a
+Java-25-capable tool version) and CI uploads the report to **Codecov** (see **CI / Automation**).
 
 ### Loader glue (mirrored in `neoforge/` and `fabric/`, package `…irontanks.<loader>`)
 
@@ -203,8 +206,9 @@ so the files reach both the mod jar and the dev resource root — no per-loader 
   Run `./gradlew spotlessApply` to fix and `./gradlew spotlessCheck` to verify.
 - Single-line `if`/`for` allowed; prefer braces for multi-line bodies; keep nesting ≤ 3 levels.
 - **CI** (`check-code.yml`, JDK 25, on PRs into `mc/**`) splits into three jobs: `lint`
-  (`spotlessCheck`), `test` (`:core:test`), and a `build` matrix that smoke-builds each loader jar
-  once lint + test pass. Formatting is now a hard CI gate, not just the PR-title check.
+  (`spotlessCheck`), `test` (`:core:jacocoTestReport`, which also uploads coverage to Codecov), and a
+  `build` matrix that smoke-builds each loader jar once lint + test pass. Formatting is now a hard CI
+  gate, not just the PR-title check.
 
 ## Commit Messages
 
@@ -248,8 +252,11 @@ GitHub Actions in `.github/workflows/`:
 
 - **`check-pr.yml`** — validates the PR title (no-scope conventional commit, lowercase subject).
 - **`check-code.yml`** — JDK 25 on push/PR into `mc/**`; three jobs: `lint` (`spotlessCheck`), `test`
-  (`:core:test`), and a `build` matrix (`[fabric, neoforge]`) that smoke-builds each loader jar and
-  runs only after lint + test pass. JDK/Gradle setup is shared via the `setup-build` composite action.
+  (`:core:jacocoTestReport`), and a `build` matrix (`[fabric, neoforge]`) that smoke-builds each loader
+  jar and runs only after lint + test pass. JDK/Gradle setup is shared via the `setup-build` composite
+  action. The `test` job uploads JaCoCo coverage to **Codecov** via `codecov/codecov-action` (needs the
+  `CODECOV_TOKEN` secret); `codecov.yml` scopes the `project`/`patch` `auto` status checks to `core/`
+  and ignores the (test-free) loader modules.
 - **`prepare-release.yml`** — runs release-please on pushes to `mc/*`.
 - **`build-release.yml`** — on a published release (or manual `workflow_dispatch`), builds **both** loader
   jars (matrix `[fabric, neoforge]`) and, when publishing, uploads to Modrinth/CurseForge via `mc-publish`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,6 +69,7 @@ toolchains, so changes do **not** cherry-pick between them — port by hand. Wit
 ```bash
 ./gradlew build                 # Build everything: core (+ unit tests), fabric, neoforge
 ./gradlew :core:test            # Run the pure-logic unit tests (no Minecraft, fast)
+./gradlew :core:jacocoTestReport # Run core tests + write the JaCoCo coverage report (XML for Codecov)
 ./gradlew :neoforge:runClient   # Launch the NeoForge dev client
 ./gradlew :fabric:runClient     # Launch the Fabric dev client
 ./gradlew :neoforge:jar         # Build just the NeoForge mod jar
@@ -145,7 +146,9 @@ than the source-injection / Architectury approaches; Iron Tanks is the testbed f
 - `VoidTank` — the 20 mB/tick self-destruction rate.
 - `TankUpgrade` — the upgrade graph (which tier promotes to which).
 
-`core` has JUnit tests and no MC dependency, so `./gradlew :core:test` runs instantly.
+`core` has JUnit tests and no MC dependency, so `./gradlew :core:test` runs instantly. It's the only
+module with a test source set; **JaCoCo** measures its coverage (`:core:jacocoTestReport`, pinned to a
+Java-25-capable tool version) and CI uploads the report to **Codecov** (see **CI / Automation**).
 
 ### Loader glue (mirrored in `neoforge/` and `fabric/`, package `…irontanks.<loader>`)
 
@@ -203,8 +206,9 @@ so the files reach both the mod jar and the dev resource root — no per-loader 
   Run `./gradlew spotlessApply` to fix and `./gradlew spotlessCheck` to verify.
 - Single-line `if`/`for` allowed; prefer braces for multi-line bodies; keep nesting ≤ 3 levels.
 - **CI** (`check-code.yml`, JDK 25, on PRs into `mc/**`) splits into three jobs: `lint`
-  (`spotlessCheck`), `test` (`:core:test`), and a `build` matrix that smoke-builds each loader jar
-  once lint + test pass. Formatting is now a hard CI gate, not just the PR-title check.
+  (`spotlessCheck`), `test` (`:core:jacocoTestReport`, which also uploads coverage to Codecov), and a
+  `build` matrix that smoke-builds each loader jar once lint + test pass. Formatting is now a hard CI
+  gate, not just the PR-title check.
 
 ## Commit Messages
 
@@ -248,8 +252,11 @@ GitHub Actions in `.github/workflows/`:
 
 - **`check-pr.yml`** — validates the PR title (no-scope conventional commit, lowercase subject).
 - **`check-code.yml`** — JDK 25 on push/PR into `mc/**`; three jobs: `lint` (`spotlessCheck`), `test`
-  (`:core:test`), and a `build` matrix (`[fabric, neoforge]`) that smoke-builds each loader jar and
-  runs only after lint + test pass. JDK/Gradle setup is shared via the `setup-build` composite action.
+  (`:core:jacocoTestReport`), and a `build` matrix (`[fabric, neoforge]`) that smoke-builds each loader
+  jar and runs only after lint + test pass. JDK/Gradle setup is shared via the `setup-build` composite
+  action. The `test` job uploads JaCoCo coverage to **Codecov** via `codecov/codecov-action` (needs the
+  `CODECOV_TOKEN` secret); `codecov.yml` scopes the `project`/`patch` `auto` status checks to `core/`
+  and ignores the (test-free) loader modules.
 - **`prepare-release.yml`** — runs release-please on pushes to `mc/*`.
 - **`build-release.yml`** — on a published release (or manual `workflow_dispatch`), builds **both** loader
   jars (matrix `[fabric, neoforge]`) and, when publishing, uploads to Modrinth/CurseForge via `mc-publish`

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,34 @@
+# Codecov configuration for Iron Tanks.
+# Only the pure-logic `core` module has tests today; fabric/neoforge are smoke-built only
+# and are ignored so they never report as 0%-covered or drag the project status down.
+coverage:
+  status:
+    project:
+      core:
+        target: auto
+        threshold: 1% # absorb noise from tiny line-count swings; tune up if flaky
+        flags:
+          - core
+        paths:
+          - core/
+    patch:
+      core:
+        target: auto
+        threshold: 1%
+        flags:
+          - core
+        paths:
+          - core/
+
+flags:
+  core:
+    paths:
+      - core/
+    carryforward: true # PRs that don't touch core keep the last known core coverage
+
+# Loaders have no tests; keep them out of coverage entirely.
+ignore:
+  - "fabric/**"
+  - "neoforge/**"
+  - "**/build/**"
+  - "**/*.gradle"

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -3,11 +3,18 @@
 // fully unit-testable without a game running. Each loader depends on it via project(':core').
 plugins {
     id 'java-library'
+    id 'jacoco'
 }
 
 java {
     toolchain.languageVersion = JavaLanguageVersion.of(rootProject.java_version.toInteger())
     withSourcesJar()
+}
+
+// JaCoCo 0.8.14 is the first release that officially supports Java 25 bytecode (class major v69);
+// Gradle's bundled default is older and would fail to instrument. Bump in lockstep with java_version.
+jacoco {
+    toolVersion = rootProject.jacoco_version
 }
 
 repositories {
@@ -38,5 +45,16 @@ test {
     testLogging {
         events 'passed', 'skipped', 'failed'
         exceptionFormat = 'full'
+    }
+    finalizedBy jacocoTestReport
+}
+
+// XML report is what Codecov consumes; HTML is handy for local inspection.
+jacocoTestReport {
+    dependsOn test
+    reports {
+        xml.required = true
+        html.required = true
+        csv.required = false
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -41,6 +41,8 @@ slf4j_version=2.0.17
 # Test Dependencies
 junit_version=5.11.0
 assertj_version=3.26.0
+# JaCoCo 0.8.14 is the first release with official Java 25 (class major v69) support.
+jacoco_version=0.8.14
 
 # Code formatting (Spotless: palantir-java-format for Java, gson for JSON)
 spotless_version=8.6.0


### PR DESCRIPTION
## Summary

Adds test-coverage measurement and uploads it to Codecov. Coverage is tracked for the pure-logic `core` module — the only module with unit tests today. The `fabric`/`neoforge` loader glue has no test source set (it's smoke-built), so it's excluded rather than reported as 0%.

## Changes

- **JaCoCo on `core`** — applies the `jacoco` plugin and pins `toolVersion` to `0.8.14`, the first release with official Java 25 support (older versions can't instrument class-file v69). Version lives in `gradle.properties` per the centralized-versions convention.
- **`core` test task** now produces a JaCoCo XML report (`core/build/reports/jacoco/test/jacocoTestReport.xml`).
- **CI** — the `test` job runs `:core:jacocoTestReport` and uploads the result to Codecov via `codecov/codecov-action` (SHA-pinned, `flags: core`, `fail_ci_if_error: false` so a Codecov blip never blocks a merge).
- **`codecov.yml`** — `project` and `patch` statuses both `target: auto`, scoped to `core/`; loaders are ignored. A reusable `core` flag is the seam for adding loader coverage later without restructuring.

## Notes

- Verified locally: `./gradlew :core:jacocoTestReport` builds clean on JDK 25, the XML lands at the expected path, Spotless passes, and `codecov.yml` validates against the Codecov API.
- Making `codecov/project/core` / `codecov/patch/core` required checks is a separate branch-protection decision — leaving that until the statuses are seen working on this PR.