### PR TITLE
fix: prevent fluid amount overflow in the NeoForge tank adapter

### DIFF
--- a/neoforge/src/main/java/com/indemnity83/irontanks/neoforge/content/TankFluidHandler.java
+++ b/neoforge/src/main/java/com/indemnity83/irontanks/neoforge/content/TankFluidHandler.java
@@ -104,7 +104,7 @@ public final class TankFluidHandler extends SnapshotJournal<TankFluidHandler.Sna
         }
         updateSnapshots(transaction);
         distribute(column, resource, total + room);
-        return (int) room;
+        return clampToInt(room);
     }
 
     @Override
@@ -131,7 +131,15 @@ public final class TankFluidHandler extends SnapshotJournal<TankFluidHandler.Sna
         }
         updateSnapshots(transaction);
         distribute(column, current, total - taken);
-        return (int) taken;
+        return clampToInt(taken);
+    }
+
+    /**
+     * Narrows a non-negative mB {@code amount} to {@code int}, clamping at {@link Integer#MAX_VALUE} so a
+     * tall column of high-tier tanks can't wrap a {@code long} total to a negative or truncated value.
+     */
+    private static int clampToInt(long amount) {
+        return (int) Math.min(amount, Integer.MAX_VALUE);
     }
 
     /** Settles {@code total} mB across the column (via {@code core}) and writes each tank's share. */


### PR DESCRIPTION
## Summary
A tall stack of high-tier tanks can hold more millibuckets than fit in a 32-bit `int`. The NeoForge fluid adapter narrowed the column's fill/drain amounts with unguarded `(int)` casts, so very large amounts could wrap to a negative or truncated value — corrupting how much fluid a pipe or pump sees it can move.

## Changes
- Clamp the `insert` (`room`) and `extract` (`taken`) return values to `Integer.MAX_VALUE` before narrowing to `int`, via a small `clampToInt` helper in `TankFluidHandler`.

## Notes
- Pure adapter-boundary fix; `core` already works in `long` mB, so no logic changes there.

Closes #111