### PR TITLE
refactor: use the #c:obsidian conventional tag for obsidian recipes

### DIFF
--- a/resources/data/c/tags/item/obsidian.json
+++ b/resources/data/c/tags/item/obsidian.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:obsidian"
+  ]
+}

--- a/resources/data/irontanks/recipe/diamond_obsidian_tank.json
+++ b/resources/data/irontanks/recipe/diamond_obsidian_tank.json
@@ -6,7 +6,7 @@
     "ooo"
   ],
   "key": {
-    "o": "minecraft:obsidian",
+    "o": "#c:obsidian",
     "t": "irontanks:diamond_tank"
   },
   "result": {

--- a/resources/data/irontanks/recipe/diamond_obsidian_upgrade.json
+++ b/resources/data/irontanks/recipe/diamond_obsidian_upgrade.json
@@ -6,7 +6,7 @@
     "ooo"
   ],
   "key": {
-    "o": "minecraft:obsidian",
+    "o": "#c:obsidian",
     "d": "#c:gems/diamond"
   },
   "result": {


### PR DESCRIPTION
## Summary
The two obsidian crafting recipes hardcoded `minecraft:obsidian` instead of the conventional `#c:obsidian` tag the rest of the mod uses (iron, glass, diamond, …). Hardcoding the vanilla item means modded obsidian can't satisfy the recipe, breaking cross-mod compatibility.

## Changes
- `diamond_obsidian_tank.json` and `diamond_obsidian_upgrade.json` now key `"o"` on `#c:obsidian`.
- Add a `c:obsidian` item-tag declaration (`resources/data/c/tags/item/obsidian.json`) populated with `minecraft:obsidian`, so vanilla obsidian satisfies the recipe out of the box and any modded obsidian added to the tag lights up automatically.

## Notes
- Mirrors the existing convention-tag pattern used for the iron/glass/silver recipes.

Closes #112