### PR TITLE
test: restore user.name when LogScrubberTest leaves it unset

### DIFF
--- a/core/src/test/java/com/indemnity83/irontanks/core/crash/LogScrubberTest.java
+++ b/core/src/test/java/com/indemnity83/irontanks/core/crash/LogScrubberTest.java
@@ -58,6 +58,8 @@ class LogScrubberTest {
         } finally {
             if (original != null) {
                 System.setProperty("user.name", original);
+            } else {
+                System.clearProperty("user.name");
             }
         }
     }


### PR DESCRIPTION
## Summary
`LogScrubberTest` overwrites the `user.name` JVM property to exercise the username redaction, then only restores it in teardown when the saved original was non-null. If `user.name` was unset before the test ran, the test left it set — leaking global JVM state into any test that ran afterward.

## Changes
- In the `finally` block, `clearProperty("user.name")` when the original value was `null`, so the property is restored to *unset* rather than left at the test's value.

## Notes
- Test-only change in `core`; no production code affected.

Closes #115