### PR TITLE
ci: use a read-only Gradle cache in publish workflows

### DIFF
--- a/.github/workflows/build-prerelease.yml
+++ b/.github/workflows/build-prerelease.yml
@@ -38,6 +38,8 @@ jobs:
         uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
         with:
           cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+          # Publish jobs read the cache but never write it, so a poisoned entry can't be baked into a release.
+          cache-read-only: true
 
       - name: Extract version information
         id: version

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -47,6 +47,8 @@ jobs:
         uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
         with:
           cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+          # Publish jobs read the cache but never write it, so a poisoned entry can't be baked into a release.
+          cache-read-only: true
 
       - name: Extract version information
         id: version

--- a/.github/workflows/build-snapshot.yml
+++ b/.github/workflows/build-snapshot.yml
@@ -38,6 +38,8 @@ jobs:
         uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
         with:
           cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+          # Publish jobs read the cache but never write it, so a poisoned entry can't be baked into a release.
+          cache-read-only: true
 
       - name: Extract version information
         id: version


### PR DESCRIPTION
## Summary
The release/snapshot/prerelease jobs produce published artifacts but let `gradle/actions/setup-gradle` write cache entries. For jobs that publish to Modrinth/CurseForge, a poisoned cache entry could be persisted and reused by a later release build. Read-only caching closes that path while keeping the read-side speedup.

## Changes
- Add `cache-read-only: true` to the Setup Gradle step in `build-release.yml`, `build-snapshot.yml`, and `build-prerelease.yml`.

## Notes
- `check-code.yml` (lint/test/build CI) is left writable so it can keep warming the shared cache.

Closes #116