### PR TITLE
chore: align the dev version fallback on a single FML-valid marker

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,9 +87,11 @@ toolchains, so changes do **not** cherry-pick between them — port by hand. Wit
 - `neoforge/build/libs/irontanks-<version>.jar`
 - `fabric/build/libs/irontanks-<version>.jar`
 
-Local/dev builds default the version to `0.0.0-dev` (NeoForge rejects a non-SemVer version like
-`dev-local` at load time). CI injects the real version via the `MOD_VERSION` env var — never hard-code
-a version in source. A dev client needs JDK 25 (the project toolchain).
+Local/dev builds default the version to `0.0.0-dev-local` (NeoForge's FML rejects a version without a
+leading numeric component at load time — a bare `dev-local` throws `InvalidModFileException`). The
+fallback is defined once in the root `allprojects` block and inherited by both loaders. CI injects the
+real version via the `MOD_VERSION` env var — never hard-code a version in source. A dev client needs
+JDK 25 (the project toolchain).
 
 ### Version Management
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,9 +87,11 @@ toolchains, so changes do **not** cherry-pick between them — port by hand. Wit
 - `neoforge/build/libs/irontanks-<version>.jar`
 - `fabric/build/libs/irontanks-<version>.jar`
 
-Local/dev builds default the version to `0.0.0-dev` (NeoForge rejects a non-SemVer version like
-`dev-local` at load time). CI injects the real version via the `MOD_VERSION` env var — never hard-code
-a version in source. A dev client needs JDK 25 (the project toolchain).
+Local/dev builds default the version to `0.0.0-dev-local` (NeoForge's FML rejects a version without a
+leading numeric component at load time — a bare `dev-local` throws `InvalidModFileException`). The
+fallback is defined once in the root `allprojects` block and inherited by both loaders. CI injects the
+real version via the `MOD_VERSION` env var — never hard-code a version in source. A dev client needs
+JDK 25 (the project toolchain).
 
 ### Version Management
 

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,11 @@ plugins {
 allprojects {
     group = rootProject.maven_group
     // Version is injected by release CI via MOD_VERSION; local/dev builds get a static marker.
-    version = System.getenv("MOD_VERSION") ?: "dev-local"
+    // The marker must be SemVer: NeoForge's FML rejects a version without a leading numeric component at
+    // load time (a bare "dev-local" throws InvalidModFileException "Illegal version number specified
+    // dev-local" — verified via :neoforge:runServer). "0.0.0-dev-local" keeps FML happy while still
+    // reading as clearly unversioned. Single source of truth — the loader modules inherit this.
+    version = System.getenv("MOD_VERSION") ?: "0.0.0-dev-local"
 }
 
 // Spotless resolves its formatter (palantir-java-format) from the root project's repositories.

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -6,9 +6,6 @@ plugins {
     id 'io.sentry.jvm.gradle'
 }
 
-// Fabric is lenient about versions, but keep parity with the NeoForge module's dev version.
-version = System.getenv("MOD_VERSION") ?: "0.0.0-dev"
-
 base {
     archivesName = rootProject.archives_base_name
 }

--- a/neoforge/build.gradle
+++ b/neoforge/build.gradle
@@ -6,10 +6,6 @@ plugins {
     id 'io.sentry.jvm.gradle'
 }
 
-// NeoForge requires a valid Maven/SemVer version in neoforge.mods.toml; the root's "dev-local" marker
-// is rejected by FML at load time. CI injects a real version via MOD_VERSION.
-version = System.getenv("MOD_VERSION") ?: "0.0.0-dev"
-
 base {
     archivesName = rootProject.archives_base_name
 }


### PR DESCRIPTION
## Summary
The root `build.gradle` fell back to `dev-local` while the loader modules overrode to `0.0.0-dev` and the docs described `0.0.0-dev` — three different stories for the same thing (#113). This unifies them on one marker defined in a single place.

`dev-local` can't be used as the mod version: NeoForge's FML rejects a version without a leading numeric component at load time. Verified via `:neoforge:runServer`:

```
net.neoforged.neoforgespi.locating.InvalidModFileException: Illegal version number specified dev-local (main)
```

`0.0.0-dev-local` **is** accepted (the server loaded the mod as `Iron Tanks 0.0.0-dev-local` and reached `Done!`), so it keeps the readable "clearly unversioned" `dev-local` signal while satisfying FML's numeric-prefix requirement.

## Changes
- Define the dev fallback once in the root `allprojects` block as `0.0.0-dev-local`, with a comment recording the FML constraint and how it was verified.
- Remove the now-redundant per-loader `version` overrides in `neoforge/build.gradle` and `fabric/build.gradle` — both inherit the root value (single source of truth).
- Update `CLAUDE.md`/`AGENTS.md` to document `0.0.0-dev-local` and the reason.

## Notes
- CI is unaffected: the real version is still injected via `MOD_VERSION` and overrides the fallback.
- Verified: `./gradlew :neoforge:jar :fabric:jar` both build, and all three modules resolve to `0.0.0-dev-local`.

Closes #113