### PR TITLE
ci: publish snapshots and pre-releases without a game-version filter

### DIFF
--- a/.github/workflows/build-prerelease.yml
+++ b/.github/workflows/build-prerelease.yml
@@ -108,6 +108,10 @@ jobs:
         with:
           loaders: ${{ matrix.loader }}
           game-versions: ${{ steps.version.outputs.minecraft_version }}
+          # Pre-releases target whatever MC version (incl. pre-releases/snapshots) the branch builds
+          # against, so there's nothing to filter to "releases". mc-publish defaults this to "releases",
+          # which would drop a pre-release game version and fail the upload — so force it off.
+          game-version-filter: none
 
           modrinth-id: ${{ vars.MODRINTH_PROJECT_ID }}
           modrinth-token: ${{ secrets.MODRINTH_TOKEN }}

--- a/.github/workflows/build-snapshot.yml
+++ b/.github/workflows/build-snapshot.yml
@@ -105,6 +105,10 @@ jobs:
         with:
           loaders: ${{ matrix.loader }}
           game-versions: ${{ steps.version.outputs.minecraft_version }}
+          # Snapshots target whatever MC version (incl. pre-releases/snapshots) the branch builds
+          # against, so there's nothing to filter to "releases". mc-publish defaults this to "releases",
+          # which would drop a pre-release game version and fail the upload — so force it off.
+          game-version-filter: none
 
           modrinth-id: ${{ vars.MODRINTH_PROJECT_ID }}
           modrinth-token: ${{ secrets.MODRINTH_TOKEN }}


### PR DESCRIPTION
## Summary
Ports [Indemnity83/logistics#458](https://github.com/Indemnity83/logistics/pull/458) to Iron Tanks.

The snapshot and pre-release publish jobs pass `game-versions: <mc_version>` but no `game-version-filter`, so they fall back to `mc-publish`'s default of `releases`. When a branch builds against a **pre-release** Minecraft version (e.g. `26.2-pre-3`), there is no *released* game version yet, the filter matches nothing, and the `mc-publish` upload step fails.

## Changes
- Set `game-version-filter: none` on the publish step in `build-snapshot.yml` and `build-prerelease.yml`. These jobs target whatever MC version the branch builds against (stable, pre-release, or weekly snapshot), so there's never anything to filter to "releases."

## Notes
- Affects publishing only; no code change.
- `build-release.yml` is intentionally left as-is — releases should target a released game version, so the default `releases` filter is correct there.
- Not triggered on the current `26.1.2` (stable) branch yet, but pre-emptively fixes the same failure logistics hit on `26.2`.