### PR TITLE
feat: store potions in tanks with bottles

### DIFF
--- a/core/src/main/java/com/indemnity83/irontanks/core/TankTier.java
+++ b/core/src/main/java/com/indemnity83/irontanks/core/TankTier.java
@@ -3,8 +3,13 @@ package com.indemnity83.irontanks.core;
 /**
  * Capacity tiers for Iron Tanks, expressed in buckets. Loader-agnostic — holds no Minecraft types.
  *
- * <p>A bucket is {@link #BUCKET_VOLUME} millibuckets, matching Minecraft's fluid granularity. Fluid
- * amounts everywhere else in {@code core} are tracked in millibuckets (see {@link #capacity()}).
+ * <p>The canonical fluid unit in {@code core} is the <strong>droplet</strong> ({@link
+ * #DROPLETS_PER_BUCKET} per bucket — Minecraft's finest fluid granularity, what Fabric uses natively).
+ * Droplets are chosen because a bottle is exactly one third of a bucket ({@link #DROPLETS_PER_BOTTLE}),
+ * which is not a whole number of millibuckets; in droplets every bucket/bottle operation is exact
+ * integer arithmetic. NeoForge speaks millibuckets, so its adapter converts at the boundary using
+ * {@link #DROPLETS_PER_MB}; Fabric is already in droplets and needs no conversion. Fluid amounts
+ * everywhere else in {@code core} are tracked in droplets (see {@link #capacity()}).
  */
 public enum TankTier {
     GLASS(16),
@@ -21,8 +26,17 @@ public enum TankTier {
     /** Dispenses fluid endlessly; capacity is nominal since it never actually drains. */
     CREATIVE(1);
 
-    /** Millibuckets per bucket (Minecraft's fluid unit). */
-    public static final int BUCKET_VOLUME = 1000;
+    /** Droplets per bucket — the canonical fluid unit (matches Fabric's {@code FluidConstants.BUCKET}). */
+    public static final int DROPLETS_PER_BUCKET = 81_000;
+
+    /** Droplets per millibucket, for converting at the NeoForge (mB) boundary. */
+    public static final int DROPLETS_PER_MB = DROPLETS_PER_BUCKET / 1000; // 81
+
+    /**
+     * Droplets a single bottle holds: exactly one third of a bucket, matching vanilla cauldrons (three
+     * bottles fill a bucket). Exact in droplets — three bottles total exactly one bucket.
+     */
+    public static final int DROPLETS_PER_BOTTLE = DROPLETS_PER_BUCKET / 3; // 27_000
 
     private final int buckets;
 
@@ -35,8 +49,8 @@ public enum TankTier {
         return buckets;
     }
 
-    /** Capacity in millibuckets, the unit fluid amounts are tracked in. */
+    /** Capacity in droplets, the unit fluid amounts are tracked in. */
     public long capacity() {
-        return (long) buckets * BUCKET_VOLUME;
+        return (long) buckets * DROPLETS_PER_BUCKET;
     }
 }

--- a/core/src/main/java/com/indemnity83/irontanks/core/VoidTank.java
+++ b/core/src/main/java/com/indemnity83/irontanks/core/VoidTank.java
@@ -12,8 +12,8 @@ public final class VoidTank {
 
     private VoidTank() {}
 
-    /** Maximum millibuckets destroyed per tick. */
-    public static final long RATE = 20;
+    /** Maximum fluid destroyed per tick, in droplets (20 mB/tick — BuildCraft's default pipe rate). */
+    public static final long RATE = 20L * TankTier.DROPLETS_PER_MB; // 1620
 
     /** How much this tank destroys this tick, given its own current contents. Never negative. */
     public static long drainPerTick(long current) {

--- a/core/src/test/java/com/indemnity83/irontanks/core/FluidColumnTest.java
+++ b/core/src/test/java/com/indemnity83/irontanks/core/FluidColumnTest.java
@@ -64,4 +64,33 @@ class FluidColumnTest {
         assertThat(FluidColumn.drainable(0, 500)).isZero(); // empty
         assertThat(FluidColumn.drainable(1500, 0)).isZero(); // nothing requested
     }
+
+    @Test
+    void bucketAndBottleTransfersAreExactAndReversibleInDroplets() {
+        // Tracking fluid in droplets makes bottles (⅓ bucket) exact integers, so mixing buckets, bottles
+        // and arbitrary pipe transfers never drifts. Walks the edge case: bucket + 3 bottles, a 200 mB
+        // pipe pull, then two bottles out — deterministic to the droplet, and reversible.
+        long bucket = TankTier.DROPLETS_PER_BUCKET; // 81_000
+        long bottle = TankTier.DROPLETS_PER_BOTTLE; // 27_000
+        long pipe200mb = 200L * TankTier.DROPLETS_PER_MB; // 16_200
+        long cap = TankTier.GLASS.capacity();
+
+        long total = 0;
+        total += FluidColumn.fillable(cap, total, bucket); // +bucket
+        for (int i = 0; i < 3; i++) total += FluidColumn.fillable(cap, total, bottle); // +3 bottles
+        assertThat(total).isEqualTo(2000L * TankTier.DROPLETS_PER_MB); // exactly 2000 mB
+
+        total -= FluidColumn.drainable(total, pipe200mb); // pipe pulls 200 mB
+        total -= FluidColumn.drainable(total, bottle); // two bottles out
+        total -= FluidColumn.drainable(total, bottle);
+        assertThat(total).isEqualTo(91_800); // 1133⅓ mB, exact
+        assertThat(total / TankTier.DROPLETS_PER_MB).isEqualTo(1133); // displayed mB
+        assertThat(total % TankTier.DROPLETS_PER_MB).isEqualTo(27); // ⅓ mB carried as remainder
+
+        // Reversible: the two bottles and the pipe amount put it back to exactly 2000 mB.
+        total += FluidColumn.fillable(cap, total, bottle);
+        total += FluidColumn.fillable(cap, total, bottle);
+        total += FluidColumn.fillable(cap, total, pipe200mb);
+        assertThat(total).isEqualTo(2000L * TankTier.DROPLETS_PER_MB);
+    }
 }

--- a/core/src/test/java/com/indemnity83/irontanks/core/TankTierTest.java
+++ b/core/src/test/java/com/indemnity83/irontanks/core/TankTierTest.java
@@ -22,9 +22,17 @@ class TankTierTest {
     }
 
     @Test
-    void capacityConvertsBucketsToMillibuckets() {
-        assertThat(TankTier.GLASS.capacity()).isEqualTo(16_000L);
-        assertThat(TankTier.EMERALD.capacity()).isEqualTo(96_000L);
-        assertThat(TankTier.BUCKET_VOLUME).isEqualTo(1000);
+    void capacityConvertsBucketsToDroplets() {
+        assertThat(TankTier.GLASS.capacity()).isEqualTo(16L * 81_000); // 1_296_000
+        assertThat(TankTier.EMERALD.capacity()).isEqualTo(96L * 81_000);
+        assertThat(TankTier.DROPLETS_PER_BUCKET).isEqualTo(81_000);
+        assertThat(TankTier.DROPLETS_PER_MB).isEqualTo(81);
+    }
+
+    @Test
+    void bottleIsExactlyOneThirdOfABucket() {
+        assertThat(TankTier.DROPLETS_PER_BOTTLE).isEqualTo(27_000);
+        // Three bottles fill a bucket exactly — no rounding remainder in droplets.
+        assertThat(3 * TankTier.DROPLETS_PER_BOTTLE).isEqualTo(TankTier.DROPLETS_PER_BUCKET);
     }
 }

--- a/core/src/test/java/com/indemnity83/irontanks/core/VoidTankTest.java
+++ b/core/src/test/java/com/indemnity83/irontanks/core/VoidTankTest.java
@@ -8,9 +8,9 @@ class VoidTankTest {
 
     @Test
     void destroysAtMostTheRatePerTick() {
-        assertThat(VoidTank.RATE).isEqualTo(20);
-        assertThat(VoidTank.drainPerTick(1000)).isEqualTo(20); // plenty held -> full rate
-        assertThat(VoidTank.drainPerTick(5)).isEqualTo(5); // less than rate -> only what's there
+        assertThat(VoidTank.RATE).isEqualTo(1620); // 20 mB/tick in droplets
+        assertThat(VoidTank.drainPerTick(81_000)).isEqualTo(1620); // plenty held -> full rate
+        assertThat(VoidTank.drainPerTick(500)).isEqualTo(500); // less than rate -> only what's there
         assertThat(VoidTank.drainPerTick(0)).isZero(); // empty -> nothing
     }
 }

--- a/fabric/src/client/java/com/indemnity83/irontanks/fabric/client/TankBlockEntityRenderer.java
+++ b/fabric/src/client/java/com/indemnity83/irontanks/fabric/client/TankBlockEntityRenderer.java
@@ -15,6 +15,7 @@ import net.minecraft.client.renderer.rendertype.RenderTypes;
 import net.minecraft.client.renderer.state.level.CameraRenderState;
 import net.minecraft.client.renderer.texture.OverlayTexture;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
+import net.minecraft.core.component.DataComponents;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.material.FluidState;
 import net.minecraft.world.phys.Vec3;
@@ -73,6 +74,12 @@ public class TankBlockEntityRenderer implements BlockEntityRenderer<TankBlockEnt
             state.tintColor = tintSource != null && level instanceof BlockAndTintGetter tintGetter
                     ? tintSource.colorInWorld(fluidState.createLegacyBlock(), tintGetter, tank.getBlockPos())
                     : 0xFFFFFFFF;
+            // A potion is stored as water carrying a potion_contents component; tint it by the potion's
+            // own color so each potion reads distinctly instead of as plain water.
+            var potion = tank.fluidVariant().get(DataComponents.POTION_CONTENTS);
+            if (potion != null) {
+                state.tintColor = potion.getColor();
+            }
         } else {
             state.sprite = null;
         }

--- a/fabric/src/main/java/com/indemnity83/irontanks/fabric/content/TankBlock.java
+++ b/fabric/src/main/java/com/indemnity83/irontanks/fabric/content/TankBlock.java
@@ -5,13 +5,23 @@ import com.mojang.serialization.Codec;
 import com.mojang.serialization.MapCodec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import net.fabricmc.fabric.api.transfer.v1.fluid.FluidStorageUtil;
+import net.fabricmc.fabric.api.transfer.v1.fluid.FluidVariant;
+import net.fabricmc.fabric.api.transfer.v1.storage.StorageView;
+import net.fabricmc.fabric.api.transfer.v1.transaction.Transaction;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.core.component.DataComponentPatch;
+import net.minecraft.core.component.DataComponents;
+import net.minecraft.sounds.SoundEvents;
+import net.minecraft.sounds.SoundSource;
 import net.minecraft.util.RandomSource;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import net.minecraft.world.item.alchemy.PotionContents;
+import net.minecraft.world.item.alchemy.Potions;
 import net.minecraft.world.item.context.BlockPlaceContext;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LevelReader;
@@ -24,6 +34,7 @@ import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.StateDefinition;
 import net.minecraft.world.level.block.state.properties.BooleanProperty;
+import net.minecraft.world.level.material.Fluids;
 import net.minecraft.world.phys.BlockHitResult;
 import org.jetbrains.annotations.Nullable;
 
@@ -66,7 +77,12 @@ public class TankBlock extends BaseEntityBlock {
         builder.add(JOINED_BELOW);
     }
 
-    /** Right-click with a bucket (or any fluid container) to fill the tank or fill the container from it. */
+    /**
+     * Right-click to move fluid between the tank and the held item: a bucket (or any fluid container)
+     * fills/drains a full bucket; a potion bottle deposits its contents and an empty glass bottle draws
+     * a bottle (1/3 bucket) back out. Potions are stored as water carrying a {@code potion_contents}
+     * component, so water bottles merge with real water and only water can be bottled back.
+     */
     @Override
     protected InteractionResult useItemOn(
             ItemStack stack,
@@ -76,11 +92,110 @@ public class TankBlock extends BaseEntityBlock {
             Player player,
             InteractionHand hand,
             BlockHitResult hit) {
-        if (level.getBlockEntity(pos) instanceof TankBlockEntity tank
-                && FluidStorageUtil.interactWithFluidStorage(new TankFluidStorage(tank), player, hand)) {
-            return InteractionResult.SUCCESS;
+        if (level.getBlockEntity(pos) instanceof TankBlockEntity tank) {
+            if (stack.is(Items.POTION) || stack.is(Items.GLASS_BOTTLE)) {
+                return bottleInteraction(stack, level, pos, player, hand, tank)
+                        ? InteractionResult.SUCCESS
+                        : InteractionResult.PASS;
+            }
+            if (FluidStorageUtil.interactWithFluidStorage(new TankFluidStorage(tank), player, hand)) {
+                return InteractionResult.SUCCESS;
+            }
         }
         return super.useItemOn(stack, state, level, pos, player, hand, hit);
+    }
+
+    /**
+     * Deposits a potion (held {@link Items#POTION}) into the tank or draws one out into a held
+     * {@link Items#GLASS_BOTTLE}. Returns whether a full bottle's worth actually transferred — on the
+     * client this is a non-committing dry run so the result matches the server without mutating state.
+     */
+    private static boolean bottleInteraction(
+            ItemStack stack, Level level, BlockPos pos, Player player, InteractionHand hand, TankBlockEntity tank) {
+        boolean commit = !level.isClientSide();
+        TankFluidStorage storage = new TankFluidStorage(tank);
+
+        if (stack.is(Items.POTION)) {
+            PotionContents contents = stack.get(DataComponents.POTION_CONTENTS);
+            if (contents == null) {
+                return false; // not a real potion; let vanilla handle it (e.g. drinking)
+            }
+            FluidVariant resource = isPlainWater(contents)
+                    ? FluidVariant.of(Fluids.WATER)
+                    : FluidVariant.of(
+                            Fluids.WATER,
+                            DataComponentPatch.builder()
+                                    .set(DataComponents.POTION_CONTENTS, contents)
+                                    .build());
+            try (Transaction tx = Transaction.openOuter()) {
+                if (!storage.depositBottle(resource, tx)) {
+                    return false;
+                }
+                if (!commit) {
+                    return true;
+                }
+                tx.commit();
+            }
+            level.playSound(null, pos, SoundEvents.BOTTLE_EMPTY, SoundSource.BLOCKS, 1.0F, 1.0F);
+            consumeAndReturn(player, hand, stack, new ItemStack(Items.GLASS_BOTTLE));
+            return true;
+        }
+
+        // Empty glass bottle: only water can be bottled (a non-water fluid leaves the bottle empty).
+        FluidVariant current = sharedFluid(storage);
+        if (current.isBlank() || current.getFluid() != Fluids.WATER) {
+            return false;
+        }
+        try (Transaction tx = Transaction.openOuter()) {
+            if (!storage.extractBottle(current, tx)) {
+                return false;
+            }
+            if (!commit) {
+                return true;
+            }
+            tx.commit();
+        }
+        level.playSound(null, pos, SoundEvents.BOTTLE_FILL, SoundSource.BLOCKS, 1.0F, 1.0F);
+        consumeAndReturn(player, hand, stack, bottleFor(current));
+        return true;
+    }
+
+    /** The single fluid the column currently holds, read through the storage's aggregate view. */
+    private static FluidVariant sharedFluid(TankFluidStorage storage) {
+        StorageView<FluidVariant> view = storage.iterator().next();
+        return view.getResource();
+    }
+
+    /** A water bottle with no effects, custom color, or name — stored as plain water so it stacks with it. */
+    private static boolean isPlainWater(PotionContents contents) {
+        return contents.is(Potions.WATER)
+                && contents.customEffects().isEmpty()
+                && contents.customColor().isEmpty()
+                && contents.customName().isEmpty();
+    }
+
+    /** The filled bottle a water column hands back: the stored potion, or a plain water bottle. */
+    private static ItemStack bottleFor(FluidVariant water) {
+        PotionContents contents = water.get(DataComponents.POTION_CONTENTS);
+        if (contents == null) {
+            return PotionContents.createItemStack(Items.POTION, Potions.WATER);
+        }
+        ItemStack bottle = new ItemStack(Items.POTION);
+        bottle.set(DataComponents.POTION_CONTENTS, contents);
+        return bottle;
+    }
+
+    /** Consume one of the held item and give back the result, mirroring vanilla bottle handling. */
+    private static void consumeAndReturn(Player player, InteractionHand hand, ItemStack held, ItemStack result) {
+        if (player.getAbilities().instabuild) {
+            return; // creative: don't consume the held item or spawn duplicates
+        }
+        held.shrink(1);
+        if (held.isEmpty()) {
+            player.setItemInHand(hand, result);
+        } else if (!player.getInventory().add(result)) {
+            player.drop(result, false);
+        }
     }
 
     @Nullable

--- a/fabric/src/main/java/com/indemnity83/irontanks/fabric/content/TankBlock.java
+++ b/fabric/src/main/java/com/indemnity83/irontanks/fabric/content/TankBlock.java
@@ -6,7 +6,6 @@ import com.mojang.serialization.MapCodec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import net.fabricmc.fabric.api.transfer.v1.fluid.FluidStorageUtil;
 import net.fabricmc.fabric.api.transfer.v1.fluid.FluidVariant;
-import net.fabricmc.fabric.api.transfer.v1.storage.StorageView;
 import net.fabricmc.fabric.api.transfer.v1.transaction.Transaction;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
@@ -142,7 +141,8 @@ public class TankBlock extends BaseEntityBlock {
         }
 
         // Empty glass bottle: only water can be bottled (a non-water fluid leaves the bottle empty).
-        FluidVariant current = sharedFluid(storage);
+        // currentFluid() (not the pipe-facing view) so a sealed potion is still bottle-drawable.
+        FluidVariant current = storage.currentFluid();
         if (current.isBlank() || current.getFluid() != Fluids.WATER) {
             return false;
         }
@@ -158,12 +158,6 @@ public class TankBlock extends BaseEntityBlock {
         level.playSound(null, pos, SoundEvents.BOTTLE_FILL, SoundSource.BLOCKS, 1.0F, 1.0F);
         consumeAndReturn(player, hand, stack, bottleFor(current));
         return true;
-    }
-
-    /** The single fluid the column currently holds, read through the storage's aggregate view. */
-    private static FluidVariant sharedFluid(TankFluidStorage storage) {
-        StorageView<FluidVariant> view = storage.iterator().next();
-        return view.getResource();
     }
 
     /** A water bottle with no effects, custom color, or name — stored as plain water so it stacks with it. */

--- a/fabric/src/main/java/com/indemnity83/irontanks/fabric/content/TankBlockEntity.java
+++ b/fabric/src/main/java/com/indemnity83/irontanks/fabric/content/TankBlockEntity.java
@@ -205,7 +205,13 @@ public class TankBlockEntity extends BlockEntity {
     @Override
     protected void saveAdditional(ValueOutput output) {
         super.saveAdditional(output);
-        output.putLong("Amount", amount);
+        // Store millibuckets (the historical key, unchanged) plus the sub-mB droplet remainder, so old
+        // v3.0.0 worlds (mB only) still load correctly and this stays a non-breaking, additive change.
+        output.putLong("Amount", amount / TankTier.DROPLETS_PER_MB);
+        long remainder = amount % TankTier.DROPLETS_PER_MB;
+        if (remainder != 0) {
+            output.putInt("Rem", (int) remainder);
+        }
         if (!fluid.isBlank()) {
             output.store("Fluid", FluidVariant.CODEC, fluid);
         }
@@ -214,7 +220,7 @@ public class TankBlockEntity extends BlockEntity {
     @Override
     protected void loadAdditional(ValueInput input) {
         super.loadAdditional(input);
-        amount = input.getLongOr("Amount", 0L);
+        amount = input.getLongOr("Amount", 0L) * TankTier.DROPLETS_PER_MB + input.getIntOr("Rem", 0);
         fluid = input.read("Fluid", FluidVariant.CODEC).orElse(FluidVariant.blank());
         if (amount <= 0) {
             fluid = FluidVariant.blank();

--- a/fabric/src/main/java/com/indemnity83/irontanks/fabric/content/TankFluidStorage.java
+++ b/fabric/src/main/java/com/indemnity83/irontanks/fabric/content/TankFluidStorage.java
@@ -11,6 +11,7 @@ import net.fabricmc.fabric.api.transfer.v1.storage.Storage;
 import net.fabricmc.fabric.api.transfer.v1.storage.StorageView;
 import net.fabricmc.fabric.api.transfer.v1.transaction.TransactionContext;
 import net.fabricmc.fabric.api.transfer.v1.transaction.base.SnapshotParticipant;
+import net.minecraft.core.component.DataComponents;
 
 /**
  * Exposes a whole vertical tank column to Fabric's Transfer API as one {@link Storage}{@code
@@ -51,6 +52,9 @@ public final class TankFluidStorage extends SnapshotParticipant<TankFluidStorage
         }
         List<TankBlockEntity> column = column();
         FluidVariant current = shared(column);
+        if (isPotion(current) || isPotion(resource)) {
+            return 0; // sealed: potions are deposited only via depositBottle
+        }
         if (!current.isBlank() && !current.equals(resource)) {
             return 0;
         }
@@ -75,6 +79,9 @@ public final class TankFluidStorage extends SnapshotParticipant<TankFluidStorage
         }
         List<TankBlockEntity> column = column();
         FluidVariant current = shared(column);
+        if (isPotion(current)) {
+            return 0; // sealed: potions are drawn only via extractBottle
+        }
         if (current.isBlank() || !current.equals(resource)) {
             return 0;
         }
@@ -88,6 +95,14 @@ public final class TankFluidStorage extends SnapshotParticipant<TankFluidStorage
         updateSnapshots(transaction);
         distribute(column, current, totalDroplets(column) - taken);
         return taken;
+    }
+
+    /**
+     * The column's actual fluid, including a stored potion. Unlike the sealed {@link ColumnView}, this is
+     * not hidden, so the bottle interaction can see and draw a potion that the fluid API hides from pipes.
+     */
+    public FluidVariant currentFluid() {
+        return shared(column());
     }
 
     /**
@@ -156,17 +171,19 @@ public final class TankFluidStorage extends SnapshotParticipant<TankFluidStorage
 
         @Override
         public FluidVariant getResource() {
-            return shared(column());
+            // A stored potion is bottle-only: present the tank as blank so pipes/pumps can't drain it.
+            FluidVariant current = shared(column());
+            return isPotion(current) ? FluidVariant.blank() : current;
         }
 
         @Override
         public long getAmount() {
-            return totalDroplets(column());
+            return isPotion(shared(column())) ? 0 : totalDroplets(column());
         }
 
         @Override
         public long getCapacity() {
-            return capacityDroplets(column());
+            return isPotion(shared(column())) ? 0 : capacityDroplets(column());
         }
     }
 
@@ -194,6 +211,15 @@ public final class TankFluidStorage extends SnapshotParticipant<TankFluidStorage
             long amount = settled[i];
             column.get(i).setContentsRaw(amount == 0 ? FluidVariant.blank() : fluid, amount);
         }
+    }
+
+    /**
+     * Whether a fluid is a stored potion — water carrying a {@code potion_contents} component. Potions
+     * are bottle-only: this adapter hides them from pipes/pumps so a potion can never be drained out (and
+     * silently degraded to water) or topped up through the fluid API. Bottle I/O bypasses these methods.
+     */
+    private static boolean isPotion(FluidVariant fluid) {
+        return !fluid.isBlank() && fluid.get(DataComponents.POTION_CONTENTS) != null;
     }
 
     private static FluidVariant shared(List<TankBlockEntity> column) {

--- a/fabric/src/main/java/com/indemnity83/irontanks/fabric/content/TankFluidStorage.java
+++ b/fabric/src/main/java/com/indemnity83/irontanks/fabric/content/TankFluidStorage.java
@@ -5,7 +5,6 @@ import com.indemnity83.irontanks.core.TankTier;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
-import net.fabricmc.fabric.api.transfer.v1.fluid.FluidConstants;
 import net.fabricmc.fabric.api.transfer.v1.fluid.FluidVariant;
 import net.fabricmc.fabric.api.transfer.v1.fluid.FluidVariantAttributes;
 import net.fabricmc.fabric.api.transfer.v1.storage.Storage;
@@ -19,13 +18,12 @@ import net.fabricmc.fabric.api.transfer.v1.transaction.base.SnapshotParticipant;
  * core}, so filling any tank in a stack fills the column. A creative tank never joins a column, so it
  * acts as a single endless source/sink.
  *
- * <p>Fabric measures fluid in droplets ({@link FluidConstants#BUCKET} per bucket) while the tank and
- * {@code core} work in millibuckets; this adapter converts at the boundary ({@link #DROPLETS_PER_MB}).
+ * <p>Fabric measures fluid in droplets, which is exactly the unit {@code core} and the tank store (see
+ * {@link TankTier}). So unlike the NeoForge adapter, this one needs no unit conversion — it is native
+ * droplets throughout.
  */
 public final class TankFluidStorage extends SnapshotParticipant<TankFluidStorage.Snapshot>
         implements Storage<FluidVariant> {
-
-    private static final long DROPLETS_PER_MB = FluidConstants.BUCKET / TankTier.BUCKET_VOLUME;
 
     /** A tank and its contents at transaction start, restored on abort. */
     public record Slot(TankBlockEntity tank, FluidVariant fluid, long amount) {}
@@ -51,10 +49,6 @@ public final class TankFluidStorage extends SnapshotParticipant<TankFluidStorage
         if (resource.isBlank() || maxAmount <= 0) {
             return 0;
         }
-        long maxMillibuckets = maxAmount / DROPLETS_PER_MB;
-        if (maxMillibuckets <= 0) {
-            return 0;
-        }
         List<TankBlockEntity> column = column();
         FluidVariant current = shared(column);
         if (!current.isBlank() && !current.equals(resource)) {
@@ -63,30 +57,20 @@ public final class TankFluidStorage extends SnapshotParticipant<TankFluidStorage
         if (creative()) {
             updateSnapshots(transaction);
             origin.setContentsRaw(resource, origin.capacity());
-            return maxMillibuckets * DROPLETS_PER_MB;
+            return maxAmount;
         }
-        long capacity = 0;
-        long total = 0;
-        for (TankBlockEntity tank : column) {
-            capacity += tank.capacity();
-            total += tank.amount();
-        }
-        long room = FluidColumn.fillable(capacity, total, maxMillibuckets);
+        long room = FluidColumn.fillable(capacityDroplets(column), totalDroplets(column), maxAmount);
         if (room <= 0) {
             return 0;
         }
         updateSnapshots(transaction);
-        distribute(column, resource, total + room);
-        return room * DROPLETS_PER_MB;
+        distribute(column, resource, totalDroplets(column) + room);
+        return room;
     }
 
     @Override
     public long extract(FluidVariant resource, long maxAmount, TransactionContext transaction) {
         if (resource.isBlank() || maxAmount <= 0) {
-            return 0;
-        }
-        long maxMillibuckets = maxAmount / DROPLETS_PER_MB;
-        if (maxMillibuckets <= 0) {
             return 0;
         }
         List<TankBlockEntity> column = column();
@@ -95,19 +79,62 @@ public final class TankFluidStorage extends SnapshotParticipant<TankFluidStorage
             return 0;
         }
         if (creative()) {
-            return maxMillibuckets * DROPLETS_PER_MB; // endless supply: never depletes
+            return maxAmount; // endless supply: never depletes
         }
-        long total = 0;
-        for (TankBlockEntity tank : column) {
-            total += tank.amount();
-        }
-        long taken = FluidColumn.drainable(total, maxMillibuckets);
+        long taken = FluidColumn.drainable(totalDroplets(column), maxAmount);
         if (taken <= 0) {
             return 0;
         }
         updateSnapshots(transaction);
-        distribute(column, current, total - taken);
-        return taken * DROPLETS_PER_MB;
+        distribute(column, current, totalDroplets(column) - taken);
+        return taken;
+    }
+
+    /**
+     * Deposits exactly one bottle (⅓ bucket, {@link TankTier#DROPLETS_PER_BOTTLE} droplets) of {@code
+     * resource} into the column, all-or-nothing. Returns whether a full bottle fit.
+     */
+    public boolean depositBottle(FluidVariant resource, TransactionContext transaction) {
+        if (resource.isBlank()) {
+            return false;
+        }
+        List<TankBlockEntity> column = column();
+        FluidVariant current = shared(column);
+        if (!current.isBlank() && !current.equals(resource)) {
+            return false;
+        }
+        if (creative()) {
+            updateSnapshots(transaction);
+            origin.setContentsRaw(resource, origin.capacity());
+            return true;
+        }
+        if (capacityDroplets(column) - totalDroplets(column) < TankTier.DROPLETS_PER_BOTTLE) {
+            return false;
+        }
+        updateSnapshots(transaction);
+        distribute(column, resource, totalDroplets(column) + TankTier.DROPLETS_PER_BOTTLE);
+        return true;
+    }
+
+    /** Draws exactly one bottle of {@code resource} out of the column, all-or-nothing. */
+    public boolean extractBottle(FluidVariant resource, TransactionContext transaction) {
+        if (resource.isBlank()) {
+            return false;
+        }
+        List<TankBlockEntity> column = column();
+        FluidVariant current = shared(column);
+        if (current.isBlank() || !current.equals(resource)) {
+            return false;
+        }
+        if (creative()) {
+            return true; // endless supply: never depletes
+        }
+        if (totalDroplets(column) < TankTier.DROPLETS_PER_BOTTLE) {
+            return false;
+        }
+        updateSnapshots(transaction);
+        distribute(column, current, totalDroplets(column) - TankTier.DROPLETS_PER_BOTTLE);
+        return true;
     }
 
     @Override
@@ -134,27 +161,35 @@ public final class TankFluidStorage extends SnapshotParticipant<TankFluidStorage
 
         @Override
         public long getAmount() {
-            long total = 0;
-            for (TankBlockEntity tank : column()) {
-                total += tank.amount();
-            }
-            return total * DROPLETS_PER_MB;
+            return totalDroplets(column());
         }
 
         @Override
         public long getCapacity() {
-            long capacity = 0;
-            for (TankBlockEntity tank : column()) {
-                capacity += tank.capacity();
-            }
-            return capacity * DROPLETS_PER_MB;
+            return capacityDroplets(column());
         }
     }
 
-    private static void distribute(List<TankBlockEntity> column, FluidVariant fluid, long totalMillibuckets) {
+    private static long totalDroplets(List<TankBlockEntity> column) {
+        long total = 0;
+        for (TankBlockEntity tank : column) {
+            total += tank.amount();
+        }
+        return total;
+    }
+
+    private static long capacityDroplets(List<TankBlockEntity> column) {
+        long capacity = 0;
+        for (TankBlockEntity tank : column) {
+            capacity += tank.capacity();
+        }
+        return capacity;
+    }
+
+    private static void distribute(List<TankBlockEntity> column, FluidVariant fluid, long totalDroplets) {
         long[] capacities = column.stream().mapToLong(TankBlockEntity::capacity).toArray();
         boolean gas = FluidVariantAttributes.isLighterThanAir(fluid);
-        long[] settled = FluidColumn.settle(capacities, totalMillibuckets, gas);
+        long[] settled = FluidColumn.settle(capacities, totalDroplets, gas);
         for (int i = 0; i < column.size(); i++) {
             long amount = settled[i];
             column.get(i).setContentsRaw(amount == 0 ? FluidVariant.blank() : fluid, amount);

--- a/fabric/src/main/java/com/indemnity83/irontanks/fabric/content/TankFluidStorage.java
+++ b/fabric/src/main/java/com/indemnity83/irontanks/fabric/content/TankFluidStorage.java
@@ -51,6 +51,9 @@ public final class TankFluidStorage extends SnapshotParticipant<TankFluidStorage
             return 0;
         }
         List<TankBlockEntity> column = column();
+        if (mixed(column)) {
+            return 0; // distinct fluids joined into one column: leave them alone, never aggregate
+        }
         FluidVariant current = shared(column);
         if (isPotion(current) || isPotion(resource)) {
             return 0; // sealed: potions are deposited only via depositBottle
@@ -78,6 +81,9 @@ public final class TankFluidStorage extends SnapshotParticipant<TankFluidStorage
             return 0;
         }
         List<TankBlockEntity> column = column();
+        if (mixed(column)) {
+            return 0; // distinct fluids joined into one column: leave them alone, never aggregate
+        }
         FluidVariant current = shared(column);
         if (isPotion(current)) {
             return 0; // sealed: potions are drawn only via extractBottle
@@ -114,6 +120,9 @@ public final class TankFluidStorage extends SnapshotParticipant<TankFluidStorage
             return false;
         }
         List<TankBlockEntity> column = column();
+        if (mixed(column)) {
+            return false; // distinct fluids joined into one column: leave them alone
+        }
         FluidVariant current = shared(column);
         if (!current.isBlank() && !current.equals(resource)) {
             return false;
@@ -137,6 +146,9 @@ public final class TankFluidStorage extends SnapshotParticipant<TankFluidStorage
             return false;
         }
         List<TankBlockEntity> column = column();
+        if (mixed(column)) {
+            return false; // distinct fluids joined into one column: leave them alone
+        }
         FluidVariant current = shared(column);
         if (current.isBlank() || !current.equals(resource)) {
             return false;
@@ -229,6 +241,28 @@ public final class TankFluidStorage extends SnapshotParticipant<TankFluidStorage
             }
         }
         return FluidVariant.blank();
+    }
+
+    /**
+     * Whether the column holds two or more distinct fluids — e.g. two pre-filled tanks joined by a third.
+     * {@link #shared(List)} only reports the first one, so the fluid API would otherwise sum the whole
+     * column and redistribute it as that single fluid, converting the others. Operations refuse to act on
+     * such a column, mirroring {@link TankBlockEntity#balanceColumn()}, which leaves it unsettled.
+     */
+    private static boolean mixed(List<TankBlockEntity> column) {
+        FluidVariant seen = FluidVariant.blank();
+        for (TankBlockEntity tank : column) {
+            FluidVariant fluid = tank.fluidVariant();
+            if (fluid.isBlank()) {
+                continue;
+            }
+            if (seen.isBlank()) {
+                seen = fluid;
+            } else if (!seen.equals(fluid)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     @Override

--- a/neoforge/src/main/java/com/indemnity83/irontanks/neoforge/client/TankBlockEntityRenderer.java
+++ b/neoforge/src/main/java/com/indemnity83/irontanks/neoforge/client/TankBlockEntityRenderer.java
@@ -15,6 +15,7 @@ import net.minecraft.client.renderer.rendertype.RenderTypes;
 import net.minecraft.client.renderer.state.level.CameraRenderState;
 import net.minecraft.client.renderer.texture.OverlayTexture;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
+import net.minecraft.core.component.DataComponents;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.material.FluidState;
 import net.minecraft.world.phys.Vec3;
@@ -73,6 +74,12 @@ public class TankBlockEntityRenderer implements BlockEntityRenderer<TankBlockEnt
             state.tintColor = tintSource != null && level instanceof BlockAndTintGetter tintGetter
                     ? tintSource.colorInWorld(fluidState.createLegacyBlock(), tintGetter, tank.getBlockPos())
                     : 0xFFFFFFFF;
+            // A potion is stored as water carrying a potion_contents component; tint it by the potion's
+            // own color so each potion reads distinctly instead of as plain water.
+            var potion = tank.fluidResource().get(DataComponents.POTION_CONTENTS);
+            if (potion != null) {
+                state.tintColor = potion.getColor();
+            }
         } else {
             state.sprite = null;
         }

--- a/neoforge/src/main/java/com/indemnity83/irontanks/neoforge/content/TankBlock.java
+++ b/neoforge/src/main/java/com/indemnity83/irontanks/neoforge/content/TankBlock.java
@@ -6,11 +6,17 @@ import com.mojang.serialization.MapCodec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.core.component.DataComponents;
+import net.minecraft.sounds.SoundEvents;
+import net.minecraft.sounds.SoundSource;
 import net.minecraft.util.RandomSource;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import net.minecraft.world.item.alchemy.PotionContents;
+import net.minecraft.world.item.alchemy.Potions;
 import net.minecraft.world.item.context.BlockPlaceContext;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LevelReader;
@@ -23,8 +29,11 @@ import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.StateDefinition;
 import net.minecraft.world.level.block.state.properties.BooleanProperty;
+import net.minecraft.world.level.material.Fluids;
 import net.minecraft.world.phys.BlockHitResult;
+import net.neoforged.neoforge.transfer.fluid.FluidResource;
 import net.neoforged.neoforge.transfer.fluid.FluidUtil;
+import net.neoforged.neoforge.transfer.transaction.Transaction;
 import org.jetbrains.annotations.Nullable;
 
 /**
@@ -66,7 +75,12 @@ public class TankBlock extends BaseEntityBlock {
         builder.add(JOINED_BELOW);
     }
 
-    /** Right-click with a bucket (or any fluid container) to fill the tank or fill the container from it. */
+    /**
+     * Right-click to move fluid between the tank and the held item: a bucket (or any fluid container)
+     * fills/drains a full bucket; a potion bottle deposits its contents and an empty glass bottle draws
+     * a bottle (1/3 bucket) back out. Potions are stored as water carrying a {@code potion_contents}
+     * component, so water bottles merge with real water and only water can be bottled back.
+     */
     @Override
     protected InteractionResult useItemOn(
             ItemStack stack,
@@ -76,11 +90,100 @@ public class TankBlock extends BaseEntityBlock {
             Player player,
             InteractionHand hand,
             BlockHitResult hit) {
-        if (level.getBlockEntity(pos) instanceof TankBlockEntity
-                && FluidUtil.interactWithFluidHandler(player, hand, level, pos, hit.getDirection())) {
-            return InteractionResult.SUCCESS;
+        if (level.getBlockEntity(pos) instanceof TankBlockEntity tank) {
+            if (stack.is(Items.POTION) || stack.is(Items.GLASS_BOTTLE)) {
+                return bottleInteraction(stack, level, pos, player, hand, tank)
+                        ? InteractionResult.SUCCESS
+                        : InteractionResult.PASS;
+            }
+            if (FluidUtil.interactWithFluidHandler(player, hand, level, pos, hit.getDirection())) {
+                return InteractionResult.SUCCESS;
+            }
         }
         return super.useItemOn(stack, state, level, pos, player, hand, hit);
+    }
+
+    /**
+     * Deposits a potion (held {@link Items#POTION}) into the tank or draws one out into a held
+     * {@link Items#GLASS_BOTTLE}. Returns whether a full bottle's worth actually transferred — on the
+     * client this is a non-committing dry run so the result matches the server without mutating state.
+     */
+    private static boolean bottleInteraction(
+            ItemStack stack, Level level, BlockPos pos, Player player, InteractionHand hand, TankBlockEntity tank) {
+        boolean commit = !level.isClientSide();
+        TankFluidHandler handler = new TankFluidHandler(tank);
+
+        if (stack.is(Items.POTION)) {
+            PotionContents contents = stack.get(DataComponents.POTION_CONTENTS);
+            if (contents == null) {
+                return false; // not a real potion; let vanilla handle it (e.g. drinking)
+            }
+            FluidResource resource = isPlainWater(contents)
+                    ? FluidResource.of(Fluids.WATER)
+                    : FluidResource.of(Fluids.WATER).with(DataComponents.POTION_CONTENTS, contents);
+            try (Transaction tx = Transaction.openRoot()) {
+                if (!handler.depositBottle(resource, tx)) {
+                    return false;
+                }
+                if (!commit) {
+                    return true;
+                }
+                tx.commit();
+            }
+            level.playSound(null, pos, SoundEvents.BOTTLE_EMPTY, SoundSource.BLOCKS, 1.0F, 1.0F);
+            consumeAndReturn(player, hand, stack, new ItemStack(Items.GLASS_BOTTLE));
+            return true;
+        }
+
+        // Empty glass bottle: only water can be bottled (a non-water fluid leaves the bottle empty).
+        FluidResource current = handler.getResource(0);
+        if (current.isEmpty() || current.getFluid() != Fluids.WATER) {
+            return false;
+        }
+        try (Transaction tx = Transaction.openRoot()) {
+            if (!handler.extractBottle(current, tx)) {
+                return false;
+            }
+            if (!commit) {
+                return true;
+            }
+            tx.commit();
+        }
+        level.playSound(null, pos, SoundEvents.BOTTLE_FILL, SoundSource.BLOCKS, 1.0F, 1.0F);
+        consumeAndReturn(player, hand, stack, bottleFor(current));
+        return true;
+    }
+
+    /** A water bottle with no effects, custom color, or name — stored as plain water so it stacks with it. */
+    private static boolean isPlainWater(PotionContents contents) {
+        return contents.is(Potions.WATER)
+                && contents.customEffects().isEmpty()
+                && contents.customColor().isEmpty()
+                && contents.customName().isEmpty();
+    }
+
+    /** The filled bottle a water column hands back: the stored potion, or a plain water bottle. */
+    private static ItemStack bottleFor(FluidResource water) {
+        PotionContents contents = water.get(DataComponents.POTION_CONTENTS);
+        if (contents == null) {
+            return PotionContents.createItemStack(Items.POTION, Potions.WATER);
+        }
+        ItemStack bottle = new ItemStack(Items.POTION);
+        bottle.set(DataComponents.POTION_CONTENTS, contents);
+        return bottle;
+    }
+
+    /** Consume one of the held item and give back the result, mirroring vanilla bottle handling. */
+    private static void consumeAndReturn(Player player, InteractionHand hand, ItemStack held, ItemStack result) {
+        if (player.getAbilities().instabuild) {
+            return; // creative: don't consume the held item or spawn duplicates
+        }
+        held.shrink(1);
+        if (held.isEmpty()) {
+            player.setItemInHand(hand, result);
+        } else if (!player.getInventory().add(result)) {
+            player.drop(result, false);
+        }
     }
 
     @Nullable

--- a/neoforge/src/main/java/com/indemnity83/irontanks/neoforge/content/TankBlock.java
+++ b/neoforge/src/main/java/com/indemnity83/irontanks/neoforge/content/TankBlock.java
@@ -136,7 +136,8 @@ public class TankBlock extends BaseEntityBlock {
         }
 
         // Empty glass bottle: only water can be bottled (a non-water fluid leaves the bottle empty).
-        FluidResource current = handler.getResource(0);
+        // currentFluid() (not the pipe-facing getResource) so a sealed potion is still bottle-drawable.
+        FluidResource current = handler.currentFluid();
         if (current.isEmpty() || current.getFluid() != Fluids.WATER) {
             return false;
         }

--- a/neoforge/src/main/java/com/indemnity83/irontanks/neoforge/content/TankBlockEntity.java
+++ b/neoforge/src/main/java/com/indemnity83/irontanks/neoforge/content/TankBlockEntity.java
@@ -209,7 +209,13 @@ public class TankBlockEntity extends BlockEntity {
     @Override
     protected void saveAdditional(ValueOutput output) {
         super.saveAdditional(output);
-        output.putLong("Amount", amount);
+        // Store millibuckets (the historical key, unchanged) plus the sub-mB droplet remainder, so old
+        // v3.0.0 worlds (mB only) still load correctly and this stays a non-breaking, additive change.
+        output.putLong("Amount", amount / TankTier.DROPLETS_PER_MB);
+        long remainder = amount % TankTier.DROPLETS_PER_MB;
+        if (remainder != 0) {
+            output.putInt("Rem", (int) remainder);
+        }
         if (!fluid.isEmpty()) {
             output.store("Fluid", FluidResource.CODEC, fluid);
         }
@@ -218,7 +224,7 @@ public class TankBlockEntity extends BlockEntity {
     @Override
     protected void loadAdditional(ValueInput input) {
         super.loadAdditional(input);
-        amount = input.getLongOr("Amount", 0L);
+        amount = input.getLongOr("Amount", 0L) * TankTier.DROPLETS_PER_MB + input.getIntOr("Rem", 0);
         fluid = input.read("Fluid", FluidResource.CODEC).orElse(FluidResource.EMPTY);
         if (amount <= 0) {
             fluid = FluidResource.EMPTY;

--- a/neoforge/src/main/java/com/indemnity83/irontanks/neoforge/content/TankFluidHandler.java
+++ b/neoforge/src/main/java/com/indemnity83/irontanks/neoforge/content/TankFluidHandler.java
@@ -88,6 +88,9 @@ public final class TankFluidHandler extends SnapshotJournal<TankFluidHandler.Sna
             return 0;
         }
         List<TankBlockEntity> column = column();
+        if (mixed(column)) {
+            return 0; // distinct fluids joined into one column: leave them alone, never aggregate
+        }
         FluidResource current = shared(column);
         if (isPotion(current) || isPotion(resource)) {
             return 0; // sealed: potions are deposited only via depositBottle
@@ -119,6 +122,9 @@ public final class TankFluidHandler extends SnapshotJournal<TankFluidHandler.Sna
             return 0;
         }
         List<TankBlockEntity> column = column();
+        if (mixed(column)) {
+            return 0; // distinct fluids joined into one column: leave them alone, never aggregate
+        }
         FluidResource current = shared(column);
         if (isPotion(current)) {
             return 0; // sealed: potions are drawn only via extractBottle
@@ -157,6 +163,9 @@ public final class TankFluidHandler extends SnapshotJournal<TankFluidHandler.Sna
             return false;
         }
         List<TankBlockEntity> column = column();
+        if (mixed(column)) {
+            return false; // distinct fluids joined into one column: leave them alone
+        }
         FluidResource current = shared(column);
         if (!current.isEmpty() && !current.equals(resource)) {
             return false;
@@ -183,6 +192,9 @@ public final class TankFluidHandler extends SnapshotJournal<TankFluidHandler.Sna
             return false;
         }
         List<TankBlockEntity> column = column();
+        if (mixed(column)) {
+            return false; // distinct fluids joined into one column: leave them alone
+        }
         FluidResource current = shared(column);
         if (current.isEmpty() || !current.equals(resource)) {
             return false;
@@ -237,6 +249,28 @@ public final class TankFluidHandler extends SnapshotJournal<TankFluidHandler.Sna
             }
         }
         return FluidResource.EMPTY;
+    }
+
+    /**
+     * Whether the column holds two or more distinct fluids — e.g. two pre-filled tanks joined by a third.
+     * {@link #shared(List)} only reports the first one, so the fluid API would otherwise sum the whole
+     * column and redistribute it as that single fluid, converting the others. Operations refuse to act on
+     * such a column, mirroring {@link TankBlockEntity#balanceColumn()}, which leaves it unsettled.
+     */
+    private static boolean mixed(List<TankBlockEntity> column) {
+        FluidResource seen = FluidResource.EMPTY;
+        for (TankBlockEntity tank : column) {
+            FluidResource fluid = tank.fluidResource();
+            if (fluid.isEmpty()) {
+                continue;
+            }
+            if (seen.isEmpty()) {
+                seen = fluid;
+            } else if (!seen.equals(fluid)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/neoforge/src/main/java/com/indemnity83/irontanks/neoforge/content/TankFluidHandler.java
+++ b/neoforge/src/main/java/com/indemnity83/irontanks/neoforge/content/TankFluidHandler.java
@@ -52,21 +52,14 @@ public final class TankFluidHandler extends SnapshotJournal<TankFluidHandler.Sna
     @Override
     public long getAmountAsLong(int index) {
         checkIndex(index);
-        long total = 0;
-        for (TankBlockEntity tank : column()) {
-            total += tank.amount();
-        }
-        return total;
+        // The column stores droplets; the NeoForge transfer API speaks millibuckets.
+        return totalDroplets(column()) / TankTier.DROPLETS_PER_MB;
     }
 
     @Override
     public long getCapacityAsLong(int index, FluidResource resource) {
         checkIndex(index);
-        long capacity = 0;
-        for (TankBlockEntity tank : column()) {
-            capacity += tank.capacity();
-        }
-        return capacity;
+        return capacityDroplets(column()) / TankTier.DROPLETS_PER_MB;
     }
 
     @Override
@@ -77,9 +70,9 @@ public final class TankFluidHandler extends SnapshotJournal<TankFluidHandler.Sna
     }
 
     @Override
-    public int insert(int index, FluidResource resource, int amount, TransactionContext transaction) {
+    public int insert(int index, FluidResource resource, int amountMb, TransactionContext transaction) {
         checkIndex(index);
-        if (resource.isEmpty() || amount <= 0) {
+        if (resource.isEmpty() || amountMb <= 0) {
             return 0;
         }
         List<TankBlockEntity> column = column();
@@ -90,27 +83,24 @@ public final class TankFluidHandler extends SnapshotJournal<TankFluidHandler.Sna
         if (creative()) {
             updateSnapshots(transaction);
             origin.setContentsRaw(resource, origin.capacity()); // define the source, stay full
-            return amount;
+            return amountMb;
         }
-        long capacity = 0;
-        long total = 0;
-        for (TankBlockEntity tank : column) {
-            capacity += tank.capacity();
-            total += tank.amount();
-        }
-        long room = FluidColumn.fillable(capacity, total, amount);
-        if (room <= 0) {
+        // Only whole millibuckets cross this boundary: floor the room so an existing sub-mB bottle
+        // fraction is never partially filled (which would create fluid against the pipe's mB accounting).
+        long roomMb = roomDroplets(column) / TankTier.DROPLETS_PER_MB;
+        long take = Math.min(amountMb, roomMb);
+        if (take <= 0) {
             return 0;
         }
         updateSnapshots(transaction);
-        distribute(column, resource, total + room);
-        return clampToInt(room);
+        distribute(column, resource, totalDroplets(column) + take * TankTier.DROPLETS_PER_MB);
+        return (int) take;
     }
 
     @Override
-    public int extract(int index, FluidResource resource, int amount, TransactionContext transaction) {
+    public int extract(int index, FluidResource resource, int amountMb, TransactionContext transaction) {
         checkIndex(index);
-        if (resource.isEmpty() || amount <= 0) {
+        if (resource.isEmpty() || amountMb <= 0) {
             return 0;
         }
         List<TankBlockEntity> column = column();
@@ -119,30 +109,90 @@ public final class TankFluidHandler extends SnapshotJournal<TankFluidHandler.Sna
             return 0;
         }
         if (creative()) {
-            return amount; // endless supply: never depletes
+            return amountMb; // endless supply: never depletes
         }
+        long availMb = totalDroplets(column) / TankTier.DROPLETS_PER_MB;
+        long take = Math.min(amountMb, availMb);
+        if (take <= 0) {
+            return 0;
+        }
+        updateSnapshots(transaction);
+        distribute(column, current, totalDroplets(column) - take * TankTier.DROPLETS_PER_MB);
+        return (int) take;
+    }
+
+    /**
+     * Deposits exactly one bottle (⅓ bucket, {@link TankTier#DROPLETS_PER_BOTTLE} droplets) of {@code
+     * resource} into the column, all-or-nothing. Works in droplets so the bottle is exact, bypassing the
+     * whole-mB quantization of {@link #insert}. Returns whether a full bottle fit.
+     */
+    public boolean depositBottle(FluidResource resource, TransactionContext transaction) {
+        if (resource.isEmpty()) {
+            return false;
+        }
+        List<TankBlockEntity> column = column();
+        FluidResource current = shared(column);
+        if (!current.isEmpty() && !current.equals(resource)) {
+            return false;
+        }
+        if (creative()) {
+            updateSnapshots(transaction);
+            origin.setContentsRaw(resource, origin.capacity());
+            return true;
+        }
+        if (roomDroplets(column) < TankTier.DROPLETS_PER_BOTTLE) {
+            return false;
+        }
+        updateSnapshots(transaction);
+        distribute(column, resource, totalDroplets(column) + TankTier.DROPLETS_PER_BOTTLE);
+        return true;
+    }
+
+    /**
+     * Draws exactly one bottle of {@code resource} out of the column, all-or-nothing. Returns whether a
+     * full bottle was present.
+     */
+    public boolean extractBottle(FluidResource resource, TransactionContext transaction) {
+        if (resource.isEmpty()) {
+            return false;
+        }
+        List<TankBlockEntity> column = column();
+        FluidResource current = shared(column);
+        if (current.isEmpty() || !current.equals(resource)) {
+            return false;
+        }
+        if (creative()) {
+            return true; // endless supply: never depletes
+        }
+        if (totalDroplets(column) < TankTier.DROPLETS_PER_BOTTLE) {
+            return false;
+        }
+        updateSnapshots(transaction);
+        distribute(column, current, totalDroplets(column) - TankTier.DROPLETS_PER_BOTTLE);
+        return true;
+    }
+
+    private static long totalDroplets(List<TankBlockEntity> column) {
         long total = 0;
         for (TankBlockEntity tank : column) {
             total += tank.amount();
         }
-        long taken = FluidColumn.drainable(total, amount);
-        if (taken <= 0) {
-            return 0;
+        return total;
+    }
+
+    private static long capacityDroplets(List<TankBlockEntity> column) {
+        long capacity = 0;
+        for (TankBlockEntity tank : column) {
+            capacity += tank.capacity();
         }
-        updateSnapshots(transaction);
-        distribute(column, current, total - taken);
-        return clampToInt(taken);
+        return capacity;
     }
 
-    /**
-     * Narrows a non-negative mB {@code amount} to {@code int}, clamping at {@link Integer#MAX_VALUE} so a
-     * tall column of high-tier tanks can't wrap a {@code long} total to a negative or truncated value.
-     */
-    private static int clampToInt(long amount) {
-        return (int) Math.min(amount, Integer.MAX_VALUE);
+    private static long roomDroplets(List<TankBlockEntity> column) {
+        return capacityDroplets(column) - totalDroplets(column);
     }
 
-    /** Settles {@code total} mB across the column (via {@code core}) and writes each tank's share. */
+    /** Settles {@code total} droplets across the column (via {@code core}) and writes each tank's share. */
     private static void distribute(List<TankBlockEntity> column, FluidResource fluid, long total) {
         long[] capacities = column.stream().mapToLong(TankBlockEntity::capacity).toArray();
         boolean gas = fluid.value().getFluidType().isLighterThanAir();

--- a/neoforge/src/main/java/com/indemnity83/irontanks/neoforge/content/TankFluidHandler.java
+++ b/neoforge/src/main/java/com/indemnity83/irontanks/neoforge/content/TankFluidHandler.java
@@ -4,6 +4,7 @@ import com.indemnity83.irontanks.core.FluidColumn;
 import com.indemnity83.irontanks.core.TankTier;
 import java.util.ArrayList;
 import java.util.List;
+import net.minecraft.core.component.DataComponents;
 import net.neoforged.neoforge.transfer.ResourceHandler;
 import net.neoforged.neoforge.transfer.fluid.FluidResource;
 import net.neoforged.neoforge.transfer.transaction.SnapshotJournal;
@@ -46,12 +47,17 @@ public final class TankFluidHandler extends SnapshotJournal<TankFluidHandler.Sna
     @Override
     public FluidResource getResource(int index) {
         checkIndex(index);
-        return shared(column());
+        FluidResource current = shared(column());
+        // A stored potion is bottle-only: hide it from the fluid API so pipes/buckets can't drain it.
+        return isPotion(current) ? FluidResource.EMPTY : current;
     }
 
     @Override
     public long getAmountAsLong(int index) {
         checkIndex(index);
+        if (isPotion(shared(column()))) {
+            return 0; // potion is bottle-only: report empty to the fluid API
+        }
         // The column stores droplets; the NeoForge transfer API speaks millibuckets.
         return totalDroplets(column()) / TankTier.DROPLETS_PER_MB;
     }
@@ -59,6 +65,9 @@ public final class TankFluidHandler extends SnapshotJournal<TankFluidHandler.Sna
     @Override
     public long getCapacityAsLong(int index, FluidResource resource) {
         checkIndex(index);
+        if (isPotion(shared(column()))) {
+            return 0; // sealed while holding a potion
+        }
         return capacityDroplets(column()) / TankTier.DROPLETS_PER_MB;
     }
 
@@ -66,6 +75,9 @@ public final class TankFluidHandler extends SnapshotJournal<TankFluidHandler.Sna
     public boolean isValid(int index, FluidResource resource) {
         checkIndex(index);
         FluidResource current = shared(column());
+        if (isPotion(current) || isPotion(resource)) {
+            return false; // potions never move through the fluid API
+        }
         return current.isEmpty() || current.equals(resource);
     }
 
@@ -77,6 +89,9 @@ public final class TankFluidHandler extends SnapshotJournal<TankFluidHandler.Sna
         }
         List<TankBlockEntity> column = column();
         FluidResource current = shared(column);
+        if (isPotion(current) || isPotion(resource)) {
+            return 0; // sealed: potions are deposited only via depositBottle
+        }
         if (!current.isEmpty() && !current.equals(resource)) {
             return 0;
         }
@@ -105,6 +120,9 @@ public final class TankFluidHandler extends SnapshotJournal<TankFluidHandler.Sna
         }
         List<TankBlockEntity> column = column();
         FluidResource current = shared(column);
+        if (isPotion(current)) {
+            return 0; // sealed: potions are drawn only via extractBottle
+        }
         if (current.isEmpty() || !current.equals(resource)) {
             return 0;
         }
@@ -119,6 +137,14 @@ public final class TankFluidHandler extends SnapshotJournal<TankFluidHandler.Sna
         updateSnapshots(transaction);
         distribute(column, current, totalDroplets(column) - take * TankTier.DROPLETS_PER_MB);
         return (int) take;
+    }
+
+    /**
+     * The column's actual fluid, including a stored potion. Unlike {@link #getResource} this is not
+     * sealed, so the bottle interaction can see and draw a potion that the fluid API hides from pipes.
+     */
+    public FluidResource currentFluid() {
+        return shared(column());
     }
 
     /**
@@ -211,6 +237,15 @@ public final class TankFluidHandler extends SnapshotJournal<TankFluidHandler.Sna
             }
         }
         return FluidResource.EMPTY;
+    }
+
+    /**
+     * Whether a fluid is a stored potion — water carrying a {@code potion_contents} component. Potions
+     * are bottle-only: this adapter hides them from pipes/pumps so a potion can never be drained out (and
+     * silently degraded to water) or topped up through the fluid API. Bottle I/O bypasses these methods.
+     */
+    private static boolean isPotion(FluidResource fluid) {
+        return !fluid.isEmpty() && fluid.get(DataComponents.POTION_CONTENTS) != null;
     }
 
     @Override


### PR DESCRIPTION
## Summary

Tanks can now store potions. Right-click a tank with a potion to pour it in, and with an empty glass bottle to draw one back out — just like a bucket, but a bottle holds **⅓ of a bucket**.

## Added

- **Deposit potions** by right-clicking a tank with a potion bottle; the fluid inside takes on the potion's color.
- **Extract** with an empty glass bottle — you get the stored potion back (or a water bottle if the tank holds plain water).
- **Water bottles just work**: they deposit ordinary water and stack with water from buckets and pipes; an empty bottle on any water tank gives a water bottle.
- Only water can be bottled — lava and other fluids ignore bottles. Splash and lingering potions aren't accepted.

## Notes

- **Three bottles equal exactly one bucket.** Bottle and bucket transfers are lossless and reversible, even when mixed with pipe transfers — no fluid drifts or gets stuck.
- **Existing worlds load unchanged** — the save format stays backward-compatible, so this is not a breaking change.