### PR TITLE
feat: show what a tank is holding

### DIFF
--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -45,6 +45,9 @@ dependencies {
     // lives. The 26.1 Fabric toolchain is Mojang-mapped (as is Jade's jar), so no remapping is needed and
     // a plain clientCompileOnly suffices. The class only loads when Jade is actually installed.
     clientCompileOnly "maven.modrinth:jade:${rootProject.jade_fabric_version}"
+    // Dev-only: load Jade in runClient so the HUD integration can actually be exercised. runtimeOnly (not
+    // include), so it is not bundled in the shipped jar and Jade stays optional in production.
+    clientRuntimeOnly "maven.modrinth:jade:${rootProject.jade_fabric_version}"
 
     // Sentry crash-reporting SDK. core uses it but doesn't bundle it (its dep is compileOnly), so the
     // loader supplies it: implementation puts it on the dev runtime classpath, include nests it

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -17,6 +17,12 @@ java {
 
 repositories {
     mavenCentral()
+    // Jade is published on the Modrinth maven (optional HUD integration below).
+    maven {
+        name = 'Modrinth'
+        url = 'https://api.modrinth.com/maven'
+        content { includeGroup 'maven.modrinth' }
+    }
 }
 
 loom {
@@ -34,6 +40,11 @@ dependencies {
     implementation "net.fabricmc:fabric-loader:${rootProject.fabric_loader_version}"
     implementation "net.fabricmc.fabric-api:fabric-api:${rootProject.fabric_version}"
     implementation project(':core')
+
+    // Optional Jade HUD integration: compile-only, on the client source set where the @WailaPlugin class
+    // lives. The 26.1 Fabric toolchain is Mojang-mapped (as is Jade's jar), so no remapping is needed and
+    // a plain clientCompileOnly suffices. The class only loads when Jade is actually installed.
+    clientCompileOnly "maven.modrinth:jade:${rootProject.jade_fabric_version}"
 
     // Sentry crash-reporting SDK. core uses it but doesn't bundle it (its dep is compileOnly), so the
     // loader supplies it: implementation puts it on the dev runtime classpath, include nests it

--- a/fabric/src/client/java/com/indemnity83/irontanks/fabric/client/compat/JadeTankPlugin.java
+++ b/fabric/src/client/java/com/indemnity83/irontanks/fabric/client/compat/JadeTankPlugin.java
@@ -30,7 +30,10 @@ public class JadeTankPlugin implements IWailaPlugin, IBlockComponentProvider {
 
     @Override
     public void appendTooltip(ITooltip tooltip, BlockAccessor accessor, IPluginConfig config) {
-        if (accessor.getBlockEntity() instanceof TankBlockEntity tank) {
+        // Only potions: Jade's built-in fluid bar already shows plain fluids and their amount, so adding
+        // our line there would just duplicate it. Potions are sealed from the fluid API (no bar), so our
+        // line is the only thing that identifies them.
+        if (accessor.getBlockEntity() instanceof TankBlockEntity tank && TankReadout.isPotion(tank)) {
             tooltip.add(TankReadout.describe(tank));
         }
     }

--- a/fabric/src/client/java/com/indemnity83/irontanks/fabric/client/compat/JadeTankPlugin.java
+++ b/fabric/src/client/java/com/indemnity83/irontanks/fabric/client/compat/JadeTankPlugin.java
@@ -1,0 +1,42 @@
+package com.indemnity83.irontanks.fabric.client.compat;
+
+import com.indemnity83.irontanks.fabric.IronTanksFabric;
+import com.indemnity83.irontanks.fabric.content.TankBlock;
+import com.indemnity83.irontanks.fabric.content.TankBlockEntity;
+import com.indemnity83.irontanks.fabric.content.TankReadout;
+import net.minecraft.resources.Identifier;
+import snownee.jade.api.BlockAccessor;
+import snownee.jade.api.IBlockComponentProvider;
+import snownee.jade.api.ITooltip;
+import snownee.jade.api.IWailaClientRegistration;
+import snownee.jade.api.IWailaPlugin;
+import snownee.jade.api.WailaPlugin;
+import snownee.jade.api.config.IPluginConfig;
+
+/**
+ * Optional Jade integration: shows a tank's contents on the look-at HUD, the same line the empty-hand
+ * readout puts on the action bar. Compile-only against Jade's API — this class is only loaded when Jade
+ * is installed, so the mod runs fine without it.
+ */
+@WailaPlugin(IronTanksFabric.MOD_ID)
+public class JadeTankPlugin implements IWailaPlugin, IBlockComponentProvider {
+
+    private static final Identifier UID = Identifier.fromNamespaceAndPath(IronTanksFabric.MOD_ID, "tank");
+
+    @Override
+    public void registerClient(IWailaClientRegistration registration) {
+        registration.registerBlockComponent(this, TankBlock.class);
+    }
+
+    @Override
+    public void appendTooltip(ITooltip tooltip, BlockAccessor accessor, IPluginConfig config) {
+        if (accessor.getBlockEntity() instanceof TankBlockEntity tank) {
+            tooltip.add(TankReadout.describe(tank));
+        }
+    }
+
+    @Override
+    public Identifier getUid() {
+        return UID;
+    }
+}

--- a/fabric/src/main/java/com/indemnity83/irontanks/fabric/content/TankBlock.java
+++ b/fabric/src/main/java/com/indemnity83/irontanks/fabric/content/TankBlock.java
@@ -104,6 +104,16 @@ public class TankBlock extends BaseEntityBlock {
         return super.useItemOn(stack, state, level, pos, player, hand, hit);
     }
 
+    /** Empty-hand right-click reads the tank's contents out to the action bar. */
+    @Override
+    protected InteractionResult useWithoutItem(
+            BlockState state, Level level, BlockPos pos, Player player, BlockHitResult hit) {
+        if (!level.isClientSide() && level.getBlockEntity(pos) instanceof TankBlockEntity tank) {
+            player.sendOverlayMessage(TankReadout.describe(tank));
+        }
+        return InteractionResult.SUCCESS;
+    }
+
     /**
      * Deposits a potion (held {@link Items#POTION}) into the tank or draws one out into a held
      * {@link Items#GLASS_BOTTLE}. Returns whether a full bottle's worth actually transferred — on the

--- a/fabric/src/main/java/com/indemnity83/irontanks/fabric/content/TankReadout.java
+++ b/fabric/src/main/java/com/indemnity83/irontanks/fabric/content/TankReadout.java
@@ -35,9 +35,17 @@ public final class TankReadout {
             return Component.translatable("irontanks.readout.empty");
         }
 
+        // Potions move only in bottles, so count them in bottles; plain fluids read in millibuckets.
+        PotionContents potion = fluid.get(DataComponents.POTION_CONTENTS);
+        if (potion != null) {
+            return Component.translatable(
+                    "irontanks.readout.potion",
+                    potionLabel(potion, tank.getLevel()),
+                    total / TankTier.DROPLETS_PER_BOTTLE);
+        }
         return Component.translatable(
                 "irontanks.readout.line",
-                labelFor(fluid, tank.getLevel()),
+                FluidVariantAttributes.getName(fluid),
                 Component.translatable(
                         "irontanks.readout.amount",
                         total / TankTier.DROPLETS_PER_MB,
@@ -57,12 +65,6 @@ public final class TankReadout {
             }
         }
         return false;
-    }
-
-    /** The fluid's display name, or a potion's effect line when it carries potion contents. */
-    private static Component labelFor(FluidVariant fluid, Level level) {
-        PotionContents potion = fluid.get(DataComponents.POTION_CONTENTS);
-        return potion != null ? potionLabel(potion, level) : FluidVariantAttributes.getName(fluid);
     }
 
     /** The potion's effect line ("Strength II (3:00)"), or its base name when it has no effects. */

--- a/fabric/src/main/java/com/indemnity83/irontanks/fabric/content/TankReadout.java
+++ b/fabric/src/main/java/com/indemnity83/irontanks/fabric/content/TankReadout.java
@@ -44,6 +44,21 @@ public final class TankReadout {
                         capacity / TankTier.DROPLETS_PER_MB));
     }
 
+    /**
+     * Whether the tank column holds a potion (water carrying a {@code potion_contents} component). Jade's
+     * native fluid bar already shows plain fluids, so the HUD adds our line only for potions — which are
+     * sealed from the fluid API and so would otherwise be invisible there.
+     */
+    public static boolean isPotion(TankBlockEntity tank) {
+        for (TankBlockEntity t : tank.columnTanks()) {
+            FluidVariant fluid = t.fluidVariant();
+            if (!fluid.isBlank() && fluid.get(DataComponents.POTION_CONTENTS) != null) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     /** The fluid's display name, or a potion's effect line when it carries potion contents. */
     private static Component labelFor(FluidVariant fluid, Level level) {
         PotionContents potion = fluid.get(DataComponents.POTION_CONTENTS);

--- a/fabric/src/main/java/com/indemnity83/irontanks/fabric/content/TankReadout.java
+++ b/fabric/src/main/java/com/indemnity83/irontanks/fabric/content/TankReadout.java
@@ -74,9 +74,11 @@ public final class TankReadout {
             float tickRate = level != null ? level.tickRateManager().tickrate() : 20.0F;
             PotionContents.addPotionTooltip(potion.getAllEffects(), lines::add, 1.0F, tickRate);
             if (!lines.isEmpty()) {
-                return lines.getFirst();
+                // The effect line is e.g. "Strength II (3:00)"; frame it as "Potion of …".
+                return Component.translatable("irontanks.readout.potion_of", lines.getFirst());
             }
         }
+        // Effectless potions (mundane/awkward/thick/water) already read as proper item names.
         return potion.getName("item.minecraft.potion.effect.");
     }
 }

--- a/fabric/src/main/java/com/indemnity83/irontanks/fabric/content/TankReadout.java
+++ b/fabric/src/main/java/com/indemnity83/irontanks/fabric/content/TankReadout.java
@@ -1,0 +1,65 @@
+package com.indemnity83.irontanks.fabric.content;
+
+import com.indemnity83.irontanks.core.TankTier;
+import java.util.ArrayList;
+import java.util.List;
+import net.fabricmc.fabric.api.transfer.v1.fluid.FluidVariant;
+import net.fabricmc.fabric.api.transfer.v1.fluid.FluidVariantAttributes;
+import net.minecraft.core.component.DataComponents;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.item.alchemy.PotionContents;
+import net.minecraft.world.level.Level;
+
+/**
+ * Builds a one-line, human-readable description of a tank column's contents — the placed tank shows
+ * nothing on its own, so this powers both the empty-hand readout and the Jade HUD. Reports the whole
+ * vertical column (the logical tank), and for a stored potion shows the effect line (amplifier +
+ * duration) so otherwise-identical sub-variants — Strength I vs II vs extended — read distinctly.
+ */
+public final class TankReadout {
+
+    private TankReadout() {}
+
+    public static Component describe(TankBlockEntity tank) {
+        long total = 0;
+        long capacity = 0;
+        FluidVariant fluid = FluidVariant.blank();
+        for (TankBlockEntity t : tank.columnTanks()) {
+            total += t.amount();
+            capacity += t.capacity();
+            if (fluid.isBlank() && !t.fluidVariant().isBlank()) {
+                fluid = t.fluidVariant();
+            }
+        }
+        if (fluid.isBlank() || total <= 0) {
+            return Component.translatable("irontanks.readout.empty");
+        }
+
+        return Component.translatable(
+                "irontanks.readout.line",
+                labelFor(fluid, tank.getLevel()),
+                Component.translatable(
+                        "irontanks.readout.amount",
+                        total / TankTier.DROPLETS_PER_MB,
+                        capacity / TankTier.DROPLETS_PER_MB));
+    }
+
+    /** The fluid's display name, or a potion's effect line when it carries potion contents. */
+    private static Component labelFor(FluidVariant fluid, Level level) {
+        PotionContents potion = fluid.get(DataComponents.POTION_CONTENTS);
+        return potion != null ? potionLabel(potion, level) : FluidVariantAttributes.getName(fluid);
+    }
+
+    /** The potion's effect line ("Strength II (3:00)"), or its base name when it has no effects. */
+    private static Component potionLabel(PotionContents potion, Level level) {
+        if (potion.hasEffects()) {
+            List<Component> lines = new ArrayList<>();
+            float tickRate = level != null ? level.tickRateManager().tickrate() : 20.0F;
+            PotionContents.addPotionTooltip(potion.getAllEffects(), lines::add, 1.0F, tickRate);
+            if (!lines.isEmpty()) {
+                return lines.getFirst();
+            }
+        }
+        return potion.getName("item.minecraft.potion.effect.");
+    }
+}

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -20,6 +20,9 @@
     ],
     "client": [
       "com.indemnity83.irontanks.fabric.client.IronTanksFabricClient"
+    ],
+    "jade": [
+      "com.indemnity83.irontanks.fabric.client.compat.JadeTankPlugin"
     ]
   },
   "depends": {

--- a/gradle.properties
+++ b/gradle.properties
@@ -44,6 +44,11 @@ assertj_version=3.26.0
 # JaCoCo 0.8.14 is the first release with official Java 25 (class major v69) support.
 jacoco_version=0.8.14
 
+# Jade — optional HUD integration, compile-only. Only takes effect if the player installs Jade; the
+# mod loads and works fine without it. Versions support MC 26.1.2 (see modrinth.com/mod/jade/versions).
+jade_neoforge_version=26.1.1+neoforge
+jade_fabric_version=26.1.0+fabric
+
 # Code formatting (Spotless: palantir-java-format for Java, gson for JSON)
 spotless_version=8.6.0
 palantir_version=2.91.0

--- a/neoforge/build.gradle
+++ b/neoforge/build.gradle
@@ -17,10 +17,20 @@ java {
 
 repositories {
     mavenCentral()
+    // Jade is published on the Modrinth maven (optional HUD integration below).
+    maven {
+        name = 'Modrinth'
+        url = 'https://api.modrinth.com/maven'
+        content { includeGroup 'maven.modrinth' }
+    }
 }
 
 dependencies {
     implementation project(':core')
+
+    // Optional Jade HUD integration: compile-only so we implement its plugin API without making Jade a
+    // hard dependency. The @WailaPlugin class only loads when Jade (a client mod) is actually present.
+    compileOnly "maven.modrinth:jade:${rootProject.jade_neoforge_version}"
 
     // Sentry crash-reporting SDK. core uses it but doesn't bundle it (its dep is compileOnly), so the
     // loader supplies it: implementation puts it on the dev runtime classpath, jarJar nests it

--- a/neoforge/build.gradle
+++ b/neoforge/build.gradle
@@ -31,6 +31,9 @@ dependencies {
     // Optional Jade HUD integration: compile-only so we implement its plugin API without making Jade a
     // hard dependency. The @WailaPlugin class only loads when Jade (a client mod) is actually present.
     compileOnly "maven.modrinth:jade:${rootProject.jade_neoforge_version}"
+    // Dev-only: load Jade in runClient so the HUD integration can be exercised. runtimeOnly (ModDevGradle's
+    // recommended way to add dev mods) puts it on the run classpath but never in the shipped jar.
+    runtimeOnly "maven.modrinth:jade:${rootProject.jade_neoforge_version}"
 
     // Sentry crash-reporting SDK. core uses it but doesn't bundle it (its dep is compileOnly), so the
     // loader supplies it: implementation puts it on the dev runtime classpath, jarJar nests it

--- a/neoforge/src/main/java/com/indemnity83/irontanks/neoforge/compat/JadeTankPlugin.java
+++ b/neoforge/src/main/java/com/indemnity83/irontanks/neoforge/compat/JadeTankPlugin.java
@@ -30,7 +30,10 @@ public class JadeTankPlugin implements IWailaPlugin, IBlockComponentProvider {
 
     @Override
     public void appendTooltip(ITooltip tooltip, BlockAccessor accessor, IPluginConfig config) {
-        if (accessor.getBlockEntity() instanceof TankBlockEntity tank) {
+        // Only potions: Jade's built-in fluid bar already shows plain fluids and their amount, so adding
+        // our line there would just duplicate it. Potions are sealed from the fluid API (no bar), so our
+        // line is the only thing that identifies them.
+        if (accessor.getBlockEntity() instanceof TankBlockEntity tank && TankReadout.isPotion(tank)) {
             tooltip.add(TankReadout.describe(tank));
         }
     }

--- a/neoforge/src/main/java/com/indemnity83/irontanks/neoforge/compat/JadeTankPlugin.java
+++ b/neoforge/src/main/java/com/indemnity83/irontanks/neoforge/compat/JadeTankPlugin.java
@@ -1,0 +1,42 @@
+package com.indemnity83.irontanks.neoforge.compat;
+
+import com.indemnity83.irontanks.neoforge.IronTanksNeoForge;
+import com.indemnity83.irontanks.neoforge.content.TankBlock;
+import com.indemnity83.irontanks.neoforge.content.TankBlockEntity;
+import com.indemnity83.irontanks.neoforge.content.TankReadout;
+import net.minecraft.resources.Identifier;
+import snownee.jade.api.BlockAccessor;
+import snownee.jade.api.IBlockComponentProvider;
+import snownee.jade.api.ITooltip;
+import snownee.jade.api.IWailaClientRegistration;
+import snownee.jade.api.IWailaPlugin;
+import snownee.jade.api.WailaPlugin;
+import snownee.jade.api.config.IPluginConfig;
+
+/**
+ * Optional Jade integration: shows a tank's contents on the look-at HUD, the same line the empty-hand
+ * readout puts on the action bar. Compile-only against Jade's API — this class is only loaded when Jade
+ * is installed, so the mod runs fine without it.
+ */
+@WailaPlugin(IronTanksNeoForge.MOD_ID)
+public class JadeTankPlugin implements IWailaPlugin, IBlockComponentProvider {
+
+    private static final Identifier UID = Identifier.fromNamespaceAndPath(IronTanksNeoForge.MOD_ID, "tank");
+
+    @Override
+    public void registerClient(IWailaClientRegistration registration) {
+        registration.registerBlockComponent(this, TankBlock.class);
+    }
+
+    @Override
+    public void appendTooltip(ITooltip tooltip, BlockAccessor accessor, IPluginConfig config) {
+        if (accessor.getBlockEntity() instanceof TankBlockEntity tank) {
+            tooltip.add(TankReadout.describe(tank));
+        }
+    }
+
+    @Override
+    public Identifier getUid() {
+        return UID;
+    }
+}

--- a/neoforge/src/main/java/com/indemnity83/irontanks/neoforge/content/TankBlock.java
+++ b/neoforge/src/main/java/com/indemnity83/irontanks/neoforge/content/TankBlock.java
@@ -103,6 +103,16 @@ public class TankBlock extends BaseEntityBlock {
         return super.useItemOn(stack, state, level, pos, player, hand, hit);
     }
 
+    /** Empty-hand right-click reads the tank's contents out to the action bar. */
+    @Override
+    protected InteractionResult useWithoutItem(
+            BlockState state, Level level, BlockPos pos, Player player, BlockHitResult hit) {
+        if (!level.isClientSide() && level.getBlockEntity(pos) instanceof TankBlockEntity tank) {
+            player.sendOverlayMessage(TankReadout.describe(tank));
+        }
+        return InteractionResult.SUCCESS;
+    }
+
     /**
      * Deposits a potion (held {@link Items#POTION}) into the tank or draws one out into a held
      * {@link Items#GLASS_BOTTLE}. Returns whether a full bottle's worth actually transferred — on the

--- a/neoforge/src/main/java/com/indemnity83/irontanks/neoforge/content/TankReadout.java
+++ b/neoforge/src/main/java/com/indemnity83/irontanks/neoforge/content/TankReadout.java
@@ -43,6 +43,21 @@ public final class TankReadout {
                         capacity / TankTier.DROPLETS_PER_MB));
     }
 
+    /**
+     * Whether the tank column holds a potion (water carrying a {@code potion_contents} component). Jade's
+     * native fluid bar already shows plain fluids, so the HUD adds our line only for potions — which are
+     * sealed from the fluid API and so would otherwise be invisible there.
+     */
+    public static boolean isPotion(TankBlockEntity tank) {
+        for (TankBlockEntity t : tank.columnTanks()) {
+            FluidResource fluid = t.fluidResource();
+            if (!fluid.isEmpty() && fluid.get(DataComponents.POTION_CONTENTS) != null) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     /** The fluid's display name, or a potion's effect line when it carries potion contents. */
     private static Component labelFor(FluidResource fluid, Level level) {
         PotionContents potion = fluid.get(DataComponents.POTION_CONTENTS);

--- a/neoforge/src/main/java/com/indemnity83/irontanks/neoforge/content/TankReadout.java
+++ b/neoforge/src/main/java/com/indemnity83/irontanks/neoforge/content/TankReadout.java
@@ -73,9 +73,11 @@ public final class TankReadout {
             float tickRate = level != null ? level.tickRateManager().tickrate() : 20.0F;
             PotionContents.addPotionTooltip(potion.getAllEffects(), lines::add, 1.0F, tickRate);
             if (!lines.isEmpty()) {
-                return lines.getFirst();
+                // The effect line is e.g. "Strength II (3:00)"; frame it as "Potion of …".
+                return Component.translatable("irontanks.readout.potion_of", lines.getFirst());
             }
         }
+        // Effectless potions (mundane/awkward/thick/water) already read as proper item names.
         return potion.getName("item.minecraft.potion.effect.");
     }
 }

--- a/neoforge/src/main/java/com/indemnity83/irontanks/neoforge/content/TankReadout.java
+++ b/neoforge/src/main/java/com/indemnity83/irontanks/neoforge/content/TankReadout.java
@@ -1,0 +1,64 @@
+package com.indemnity83.irontanks.neoforge.content;
+
+import com.indemnity83.irontanks.core.TankTier;
+import java.util.ArrayList;
+import java.util.List;
+import net.minecraft.core.component.DataComponents;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.item.alchemy.PotionContents;
+import net.minecraft.world.level.Level;
+import net.neoforged.neoforge.transfer.fluid.FluidResource;
+
+/**
+ * Builds a one-line, human-readable description of a tank column's contents — the placed tank shows
+ * nothing on its own, so this powers both the empty-hand readout and the Jade HUD. Reports the whole
+ * vertical column (the logical tank), and for a stored potion shows the effect line (amplifier +
+ * duration) so otherwise-identical sub-variants — Strength I vs II vs extended — read distinctly.
+ */
+public final class TankReadout {
+
+    private TankReadout() {}
+
+    public static Component describe(TankBlockEntity tank) {
+        long total = 0;
+        long capacity = 0;
+        FluidResource fluid = FluidResource.EMPTY;
+        for (TankBlockEntity t : tank.columnTanks()) {
+            total += t.amount();
+            capacity += t.capacity();
+            if (fluid.isEmpty() && !t.fluidResource().isEmpty()) {
+                fluid = t.fluidResource();
+            }
+        }
+        if (fluid.isEmpty() || total <= 0) {
+            return Component.translatable("irontanks.readout.empty");
+        }
+
+        return Component.translatable(
+                "irontanks.readout.line",
+                labelFor(fluid, tank.getLevel()),
+                Component.translatable(
+                        "irontanks.readout.amount",
+                        total / TankTier.DROPLETS_PER_MB,
+                        capacity / TankTier.DROPLETS_PER_MB));
+    }
+
+    /** The fluid's display name, or a potion's effect line when it carries potion contents. */
+    private static Component labelFor(FluidResource fluid, Level level) {
+        PotionContents potion = fluid.get(DataComponents.POTION_CONTENTS);
+        return potion != null ? potionLabel(potion, level) : fluid.getHoverName();
+    }
+
+    /** The potion's effect line ("Strength II (3:00)"), or its base name when it has no effects. */
+    private static Component potionLabel(PotionContents potion, Level level) {
+        if (potion.hasEffects()) {
+            List<Component> lines = new ArrayList<>();
+            float tickRate = level != null ? level.tickRateManager().tickrate() : 20.0F;
+            PotionContents.addPotionTooltip(potion.getAllEffects(), lines::add, 1.0F, tickRate);
+            if (!lines.isEmpty()) {
+                return lines.getFirst();
+            }
+        }
+        return potion.getName("item.minecraft.potion.effect.");
+    }
+}

--- a/neoforge/src/main/java/com/indemnity83/irontanks/neoforge/content/TankReadout.java
+++ b/neoforge/src/main/java/com/indemnity83/irontanks/neoforge/content/TankReadout.java
@@ -34,9 +34,17 @@ public final class TankReadout {
             return Component.translatable("irontanks.readout.empty");
         }
 
+        // Potions move only in bottles, so count them in bottles; plain fluids read in millibuckets.
+        PotionContents potion = fluid.get(DataComponents.POTION_CONTENTS);
+        if (potion != null) {
+            return Component.translatable(
+                    "irontanks.readout.potion",
+                    potionLabel(potion, tank.getLevel()),
+                    total / TankTier.DROPLETS_PER_BOTTLE);
+        }
         return Component.translatable(
                 "irontanks.readout.line",
-                labelFor(fluid, tank.getLevel()),
+                fluid.getHoverName(),
                 Component.translatable(
                         "irontanks.readout.amount",
                         total / TankTier.DROPLETS_PER_MB,
@@ -56,12 +64,6 @@ public final class TankReadout {
             }
         }
         return false;
-    }
-
-    /** The fluid's display name, or a potion's effect line when it carries potion contents. */
-    private static Component labelFor(FluidResource fluid, Level level) {
-        PotionContents potion = fluid.get(DataComponents.POTION_CONTENTS);
-        return potion != null ? potionLabel(potion, level) : fluid.getHoverName();
     }
 
     /** The potion's effect line ("Strength II (3:00)"), or its base name when it has no effects. */

--- a/resources/assets/irontanks/lang/en_us.json
+++ b/resources/assets/irontanks/lang/en_us.json
@@ -24,5 +24,6 @@
   "irontanks.tooltip.creative_tank": "Dispenses an infinite amount",
   "irontanks.readout.empty": "Empty",
   "irontanks.readout.line": "%1$s · %2$s",
-  "irontanks.readout.amount": "%1$s / %2$s mB"
+  "irontanks.readout.amount": "%1$s / %2$s mB",
+  "irontanks.readout.potion": "%1$s × %2$s"
 }

--- a/resources/assets/irontanks/lang/en_us.json
+++ b/resources/assets/irontanks/lang/en_us.json
@@ -25,5 +25,6 @@
   "irontanks.readout.empty": "Empty",
   "irontanks.readout.line": "%1$s · %2$s",
   "irontanks.readout.amount": "%1$s / %2$s mB",
-  "irontanks.readout.potion": "%1$s × %2$s"
+  "irontanks.readout.potion": "%1$s × %2$s",
+  "irontanks.readout.potion_of": "Potion of %s"
 }

--- a/resources/assets/irontanks/lang/en_us.json
+++ b/resources/assets/irontanks/lang/en_us.json
@@ -26,5 +26,6 @@
   "irontanks.readout.line": "%1$s · %2$s",
   "irontanks.readout.amount": "%1$s / %2$s mB",
   "irontanks.readout.potion": "%1$s × %2$s",
-  "irontanks.readout.potion_of": "Potion of %s"
+  "irontanks.readout.potion_of": "Potion of %s",
+  "config.jade.plugin_irontanks.tank": "Tank Contents"
 }

--- a/resources/assets/irontanks/lang/en_us.json
+++ b/resources/assets/irontanks/lang/en_us.json
@@ -21,5 +21,8 @@
   "item.irontanks.diamond_emerald_upgrade": "Diamond to Emerald Tank Upgrade",
   "irontanks.tooltip.capacity": "Holds %s buckets",
   "irontanks.tooltip.void_tank": "Destroys fluids",
-  "irontanks.tooltip.creative_tank": "Dispenses an infinite amount"
+  "irontanks.tooltip.creative_tank": "Dispenses an infinite amount",
+  "irontanks.readout.empty": "Empty",
+  "irontanks.readout.line": "%1$s · %2$s",
+  "irontanks.readout.amount": "%1$s / %2$s mB"
 }


### PR DESCRIPTION
## Summary

You can now see what's inside a placed tank — including *which* potion, down to its level and duration, so otherwise-identical potion tanks are no longer a guessing game.

## Added

- **Empty-hand right-click a tank** → its contents print to the action bar:
  - A potion shows its effect line, e.g. `Potion of Strength II (3:00) · 1333 / 16000 mB` — distinguishing level **and** duration.
  - A fluid shows its name and amount, e.g. `Water · 1333 / 16000 mB`.
  - An empty tank shows `Empty`.
- **Jade HUD support (optional):** with Jade installed, the same line appears on the look-at tooltip. Jade is a compile-only integration — the mod works fine without it.

## Notes

- Amounts are shown in mB (the droplet remainder a bottle can leave is rounded off for display).
- Stacked on #126 — this PR targets that branch and will retarget to `mc/26.1` once #126 merges.
- The action-bar text and the Jade HUD line are runtime/visual behaviors best confirmed with an in-game check (Jade dropped into the dev client for the HUD path).