### PR TITLE
fix: tank fluid level no longer dips when topped off

### DIFF
--- a/fabric/src/client/java/com/indemnity83/irontanks/fabric/client/TankBlockEntityRenderer.java
+++ b/fabric/src/client/java/com/indemnity83/irontanks/fabric/client/TankBlockEntityRenderer.java
@@ -29,9 +29,8 @@ public class TankBlockEntityRenderer implements BlockEntityRenderer<TankBlockEnt
     // The tank model's inner box is 2..14 px; inset the fluid horizontally to avoid z-fighting the walls.
     private static final float MIN = 2.5F / 16F;
     private static final float MAX = 13.5F / 16F;
-    // Fluid sits on the block floor (0) and a full tank's visible surface stops just shy of the lid.
+    // Fluid sits on the block floor (0); a full tank fills the whole block height — no top/bottom padding.
     private static final float FLOOR = 0.0F;
-    private static final float FULL_SURFACE = 15.5F / 16F;
 
     public TankBlockEntityRenderer(BlockEntityRendererProvider.Context context) {}
 
@@ -54,7 +53,6 @@ public class TankBlockEntityRenderer implements BlockEntityRenderer<TankBlockEnt
         Level level = tank.getLevel();
         state.hasFluid = !tank.fluidVariant().isBlank() && amount > 0 && capacity > 0 && level != null;
         state.fillRatio = state.hasFluid ? Math.min(1.0F, (float) amount / capacity) : 0.0F;
-        state.full = state.hasFluid && amount >= capacity;
         // If connected fluid continues above, hide this tank's surface and let its fluid reach the top so
         // the two tanks read as one continuous column.
         state.renderTop = state.hasFluid && !tank.hasFluidAbove();
@@ -87,8 +85,8 @@ public class TankBlockEntityRenderer implements BlockEntityRenderer<TankBlockEnt
         // getTintColor may omit alpha (0x00RRGGBB); force opaque so the surface is visible.
         int color = (state.tintColor & 0xFF000000) == 0 ? state.tintColor | 0xFF000000 : state.tintColor;
         int light = state.lightCoords;
-        // Visible surface height; a full tank stops just shy of the lid.
-        float surface = state.full ? FULL_SURFACE : state.fillRatio;
+        // Visible surface height tracks the fill ratio exactly — 1.0 when full, with no top padding.
+        float surface = state.fillRatio;
         // Walls reach the surface where it's visible, or the full block height where fluid continues above.
         float wallTop = state.renderTop ? surface : 1.0F;
         boolean renderTop = state.renderTop;

--- a/fabric/src/client/java/com/indemnity83/irontanks/fabric/client/TankRenderState.java
+++ b/fabric/src/client/java/com/indemnity83/irontanks/fabric/client/TankRenderState.java
@@ -11,8 +11,6 @@ import org.jetbrains.annotations.Nullable;
 public class TankRenderState extends BlockEntityRenderState {
     public boolean hasFluid;
     public float fillRatio;
-    /** This tank is completely full (so its fluid fills the block height). */
-    public boolean full;
     /** Draw the fluid's top surface here; false when connected fluid continues above, so columns merge. */
     public boolean renderTop;
 

--- a/neoforge/src/main/java/com/indemnity83/irontanks/neoforge/client/TankBlockEntityRenderer.java
+++ b/neoforge/src/main/java/com/indemnity83/irontanks/neoforge/client/TankBlockEntityRenderer.java
@@ -29,9 +29,8 @@ public class TankBlockEntityRenderer implements BlockEntityRenderer<TankBlockEnt
     // The tank model's inner box is 2..14 px; inset the fluid horizontally to avoid z-fighting the walls.
     private static final float MIN = 2.5F / 16F;
     private static final float MAX = 13.5F / 16F;
-    // Fluid sits on the block floor (0) and a full tank's visible surface stops just shy of the lid.
+    // Fluid sits on the block floor (0); a full tank fills the whole block height — no top/bottom padding.
     private static final float FLOOR = 0.0F;
-    private static final float FULL_SURFACE = 15.5F / 16F;
 
     public TankBlockEntityRenderer(BlockEntityRendererProvider.Context context) {}
 
@@ -54,7 +53,6 @@ public class TankBlockEntityRenderer implements BlockEntityRenderer<TankBlockEnt
         Level level = tank.getLevel();
         state.hasFluid = !tank.fluidResource().isEmpty() && amount > 0 && capacity > 0 && level != null;
         state.fillRatio = state.hasFluid ? Math.min(1.0F, (float) amount / capacity) : 0.0F;
-        state.full = state.hasFluid && amount >= capacity;
         // If connected fluid continues above, hide this tank's surface and let its fluid reach the top so
         // the two tanks read as one continuous column.
         state.renderTop = state.hasFluid && !tank.hasFluidAbove();
@@ -87,8 +85,8 @@ public class TankBlockEntityRenderer implements BlockEntityRenderer<TankBlockEnt
         // getTintColor may omit alpha (0x00RRGGBB); force opaque so the surface is visible.
         int color = (state.tintColor & 0xFF000000) == 0 ? state.tintColor | 0xFF000000 : state.tintColor;
         int light = state.lightCoords;
-        // Visible surface height; a full tank stops just shy of the lid.
-        float surface = state.full ? FULL_SURFACE : state.fillRatio;
+        // Visible surface height tracks the fill ratio exactly — 1.0 when full, with no top padding.
+        float surface = state.fillRatio;
         // Walls reach the surface where it's visible, or the full block height where fluid continues above.
         float wallTop = state.renderTop ? surface : 1.0F;
         boolean renderTop = state.renderTop;

--- a/neoforge/src/main/java/com/indemnity83/irontanks/neoforge/client/TankRenderState.java
+++ b/neoforge/src/main/java/com/indemnity83/irontanks/neoforge/client/TankRenderState.java
@@ -11,8 +11,6 @@ import org.jetbrains.annotations.Nullable;
 public class TankRenderState extends BlockEntityRenderState {
     public boolean hasFluid;
     public float fillRatio;
-    /** This tank is completely full (so its fluid fills the block height). */
-    public boolean full;
     /** Draw the fluid's top surface here; false when connected fluid continues above, so columns merge. */
     public boolean renderTop;
 


### PR DESCRIPTION
## Summary

Fixes a visual glitch where a tank's fluid level dropped slightly the instant it became completely full.

## Fixed

- A full tank's fluid now renders all the way to the top of the block. Previously a small gap was left above the fluid only when full, so topping off an almost-full tank made the visible level tick **down** instead of up. The fill surface now tracks the actual fill ratio with no top (or bottom) padding.