### PR TITLE
refactor: move the fluid-handler algorithm into core

### DIFF
--- a/core/src/main/java/com/indemnity83/irontanks/core/FluidKind.java
+++ b/core/src/main/java/com/indemnity83/irontanks/core/FluidKind.java
@@ -1,0 +1,22 @@
+package com.indemnity83.irontanks.core;
+
+/**
+ * The handful of facts {@link TankColumn} needs about a loader's fluid type {@code F} without {@code
+ * core} touching any Minecraft type. Each loader supplies one implementation over its own fluid stack
+ * (NeoForge {@code FluidResource}, Fabric {@code FluidVariant}); equality is left to {@code F}'s own
+ * {@code equals}, so there is no {@code equal} method here.
+ */
+public interface FluidKind<F> {
+
+    /** The "no fluid" value for {@code F} (NeoForge {@code FluidResource.EMPTY} / Fabric blank variant). */
+    F empty();
+
+    /** Whether {@code fluid} is the empty value. */
+    boolean isEmpty(F fluid);
+
+    /** Whether {@code fluid} is lighter than air, so it settles toward the top of a column. */
+    boolean isGas(F fluid);
+
+    /** Whether {@code fluid} is a stored potion (water carrying a {@code potion_contents} component). */
+    boolean isPotion(F fluid);
+}

--- a/core/src/main/java/com/indemnity83/irontanks/core/TankCell.java
+++ b/core/src/main/java/com/indemnity83/irontanks/core/TankCell.java
@@ -1,0 +1,25 @@
+package com.indemnity83.irontanks.core;
+
+/**
+ * One tank in a vertical column, abstracted over the loader's block entity so {@link TankColumn} can
+ * read and rewrite its contents without any Minecraft type. Each loader's {@code TankBlockEntity}
+ * implements this directly (it already exposes {@link #tier()}, {@link #capacity()}, {@link #amount()}).
+ * All amounts are in droplets — the canonical unit (see {@link TankTier}).
+ */
+public interface TankCell<F> {
+
+    /** This tank's tier — lets {@code core} recognise a {@link TankTier#CREATIVE} cell itself. */
+    TankTier tier();
+
+    /** Capacity in droplets. */
+    long capacity();
+
+    /** Current contents in droplets. */
+    long amount();
+
+    /** The fluid currently held, or the kind's empty value. */
+    F fluid();
+
+    /** Raw write of {@code fluid} + {@code amount} (droplets), no client sync — the caller handles that. */
+    void setContents(F fluid, long amount);
+}

--- a/core/src/main/java/com/indemnity83/irontanks/core/TankColumn.java
+++ b/core/src/main/java/com/indemnity83/irontanks/core/TankColumn.java
@@ -115,6 +115,7 @@ public final class TankColumn<F> {
      * potion, holds a different fluid, or is full). A creative column becomes the source and stays full.
      */
     public long insert(F resource, long maxDroplets, long quantum, Runnable onMutate) {
+        requirePositiveQuantum(quantum);
         if (kind.isEmpty(resource) || maxDroplets <= 0) {
             return 0;
         }
@@ -148,6 +149,7 @@ public final class TankColumn<F> {
      * different fluid). A creative column is endless and never depletes.
      */
     public long extract(F resource, long maxDroplets, long quantum, Runnable onMutate) {
+        requirePositiveQuantum(quantum);
         if (kind.isEmpty(resource) || maxDroplets <= 0) {
             return 0;
         }
@@ -269,5 +271,11 @@ public final class TankColumn<F> {
     /** Floors a non-negative {@code value} to a whole multiple of {@code quantum}. */
     private static long floorTo(long value, long quantum) {
         return value - (value % quantum);
+    }
+
+    private static void requirePositiveQuantum(long quantum) {
+        if (quantum <= 0) {
+            throw new IllegalArgumentException("quantum must be > 0: " + quantum);
+        }
     }
 }

--- a/core/src/main/java/com/indemnity83/irontanks/core/TankColumn.java
+++ b/core/src/main/java/com/indemnity83/irontanks/core/TankColumn.java
@@ -1,0 +1,273 @@
+package com.indemnity83.irontanks.core;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * The whole tank-column fluid algorithm, owned once in {@code core} instead of copied into each
+ * loader's transfer-API adapter. A column is an {@code origin} cell plus the connected cells ordered
+ * bottom-to-top, all sharing one {@link FluidKind}. Every operation works in droplets and re-settles
+ * the column via {@link FluidColumn} (liquids to the bottom, gases to the top).
+ *
+ * <p>The rules live here so they are unit-testable without a game:
+ *
+ * <ul>
+ *   <li><b>Mixed columns</b> (two distinct fluids joined together) are never aggregated — every
+ *       operation refuses, mirroring {@link #rebalance()} leaving them unsettled.
+ *   <li><b>Potions</b> are sealed from the fluid path: {@link #insert}/{@link #extract} reject them, so
+ *       they move only through {@link #depositBottle}/{@link #extractBottle}.
+ *   <li><b>Creative</b> tanks are an endless source/sink and never join a column (single-cell column).
+ * </ul>
+ *
+ * <p>Loaders that report fluid in coarser units than droplets pass a {@code quantum} to insert/extract:
+ * the amount moved is floored to a whole multiple of it, so a sub-quantum remainder (e.g. a stored
+ * bottle fraction) is never partially filled. Fabric passes {@code quantum = 1} (native droplets);
+ * NeoForge passes {@link TankTier#DROPLETS_PER_MB} and converts the droplet result back to millibuckets.
+ *
+ * <p>Mutating methods take an {@code onMutate} hook run exactly once immediately before the first write,
+ * so a loader can capture its transaction snapshot only when the column is actually about to change.
+ */
+public final class TankColumn<F> {
+
+    private final TankCell<F> origin;
+    private final List<? extends TankCell<F>> cells;
+    private final FluidKind<F> kind;
+
+    /** @param cells the column ordered bottom-to-top; {@code origin} is the cell the operation entered through */
+    public TankColumn(TankCell<F> origin, List<? extends TankCell<F>> cells, FluidKind<F> kind) {
+        this.origin = origin;
+        this.cells = cells;
+        this.kind = kind;
+    }
+
+    private boolean creative() {
+        return origin.tier() == TankTier.CREATIVE;
+    }
+
+    // ==================== aggregation ====================
+
+    /** Total contents of the column, in droplets. */
+    public long total() {
+        long total = 0;
+        for (TankCell<F> cell : cells) {
+            total += cell.amount();
+        }
+        return total;
+    }
+
+    /** Total capacity of the column, in droplets. */
+    public long capacity() {
+        long capacity = 0;
+        for (TankCell<F> cell : cells) {
+            capacity += cell.capacity();
+        }
+        return capacity;
+    }
+
+    /** Free space left in the column, in droplets. */
+    public long room() {
+        return capacity() - total();
+    }
+
+    /** The single fluid the column holds, or the kind's empty value if it is empty. */
+    public F shared() {
+        for (TankCell<F> cell : cells) {
+            if (!kind.isEmpty(cell.fluid())) {
+                return cell.fluid();
+            }
+        }
+        return kind.empty();
+    }
+
+    /**
+     * Whether the column holds two or more distinct fluids — e.g. two pre-filled tanks joined by a
+     * third. {@link #shared()} reports only the first, so an operation that trusted it would sum the
+     * whole column and redistribute it as that one fluid, silently converting the others. Operations
+     * refuse to act on such a column.
+     */
+    public boolean mixed() {
+        F seen = kind.empty();
+        for (TankCell<F> cell : cells) {
+            F fluid = cell.fluid();
+            if (kind.isEmpty(fluid)) {
+                continue;
+            }
+            if (kind.isEmpty(seen)) {
+                seen = fluid;
+            } else if (!Objects.equals(seen, fluid)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /** Whether {@code fluid} is a sealed potion (delegates to the kind). */
+    public boolean isPotion(F fluid) {
+        return kind.isPotion(fluid);
+    }
+
+    // ==================== fluid-API operations ====================
+
+    /**
+     * Adds up to {@code maxDroplets} of {@code resource} to the column, floored to a whole multiple of
+     * {@code quantum}. Returns the droplets actually added (0 if the column is mixed, sealed by a
+     * potion, holds a different fluid, or is full). A creative column becomes the source and stays full.
+     */
+    public long insert(F resource, long maxDroplets, long quantum, Runnable onMutate) {
+        if (kind.isEmpty(resource) || maxDroplets <= 0) {
+            return 0;
+        }
+        if (mixed()) {
+            return 0;
+        }
+        F current = shared();
+        if (kind.isPotion(current) || kind.isPotion(resource)) {
+            return 0; // sealed: potions are deposited only via depositBottle
+        }
+        if (!kind.isEmpty(current) && !Objects.equals(current, resource)) {
+            return 0;
+        }
+        if (creative()) {
+            onMutate.run();
+            origin.setContents(resource, origin.capacity()); // define the source, stay full
+            return floorTo(maxDroplets, quantum);
+        }
+        long take = Math.min(floorTo(maxDroplets, quantum), floorTo(room(), quantum));
+        if (take <= 0) {
+            return 0;
+        }
+        onMutate.run();
+        distribute(resource, total() + take);
+        return take;
+    }
+
+    /**
+     * Removes up to {@code maxDroplets} of {@code resource} from the column, floored to a whole multiple
+     * of {@code quantum}. Returns the droplets actually removed (0 if mixed, sealed, empty, or holding a
+     * different fluid). A creative column is endless and never depletes.
+     */
+    public long extract(F resource, long maxDroplets, long quantum, Runnable onMutate) {
+        if (kind.isEmpty(resource) || maxDroplets <= 0) {
+            return 0;
+        }
+        if (mixed()) {
+            return 0;
+        }
+        F current = shared();
+        if (kind.isPotion(current)) {
+            return 0; // sealed: potions are drawn only via extractBottle
+        }
+        if (kind.isEmpty(current) || !Objects.equals(current, resource)) {
+            return 0;
+        }
+        if (creative()) {
+            return floorTo(maxDroplets, quantum); // endless supply: never depletes
+        }
+        long take = Math.min(floorTo(maxDroplets, quantum), floorTo(total(), quantum));
+        if (take <= 0) {
+            return 0;
+        }
+        onMutate.run();
+        distribute(current, total() - take);
+        return take;
+    }
+
+    /**
+     * Deposits exactly one bottle ({@link TankTier#DROPLETS_PER_BOTTLE} droplets) of {@code resource},
+     * all-or-nothing and droplet-exact (no quantum). Returns whether a full bottle fit.
+     */
+    public boolean depositBottle(F resource, Runnable onMutate) {
+        if (kind.isEmpty(resource)) {
+            return false;
+        }
+        if (mixed()) {
+            return false;
+        }
+        F current = shared();
+        if (!kind.isEmpty(current) && !Objects.equals(current, resource)) {
+            return false;
+        }
+        if (creative()) {
+            onMutate.run();
+            origin.setContents(resource, origin.capacity());
+            return true;
+        }
+        if (room() < TankTier.DROPLETS_PER_BOTTLE) {
+            return false;
+        }
+        onMutate.run();
+        distribute(resource, total() + TankTier.DROPLETS_PER_BOTTLE);
+        return true;
+    }
+
+    /** Draws exactly one bottle of {@code resource} out of the column, all-or-nothing. */
+    public boolean extractBottle(F resource, Runnable onMutate) {
+        if (kind.isEmpty(resource)) {
+            return false;
+        }
+        if (mixed()) {
+            return false;
+        }
+        F current = shared();
+        if (kind.isEmpty(current) || !Objects.equals(current, resource)) {
+            return false;
+        }
+        if (creative()) {
+            return true; // endless supply: never depletes
+        }
+        if (total() < TankTier.DROPLETS_PER_BOTTLE) {
+            return false;
+        }
+        onMutate.run();
+        distribute(current, total() - TankTier.DROPLETS_PER_BOTTLE);
+        return true;
+    }
+
+    // ==================== settling ====================
+
+    /**
+     * Re-settles the column's existing contents (liquids down, gases up) and writes each cell's share.
+     * Returns the cells whose contents changed (empty if nothing moved, the column is empty, or it holds
+     * mixed fluids and is therefore left alone). The caller syncs the returned cells.
+     */
+    public List<TankCell<F>> rebalance() {
+        F shared = shared();
+        if (kind.isEmpty(shared) || mixed()) {
+            return List.of();
+        }
+        long[] settled = settle(shared, total());
+        List<TankCell<F>> changed = new ArrayList<>();
+        for (int i = 0; i < cells.size(); i++) {
+            TankCell<F> cell = cells.get(i);
+            long target = settled[i];
+            F targetFluid = target == 0 ? kind.empty() : shared;
+            if (cell.amount() != target || !Objects.equals(cell.fluid(), targetFluid)) {
+                cell.setContents(targetFluid, target);
+                changed.add(cell);
+            }
+        }
+        return changed;
+    }
+
+    private void distribute(F fluid, long totalDroplets) {
+        long[] settled = settle(fluid, totalDroplets);
+        for (int i = 0; i < cells.size(); i++) {
+            long amount = settled[i];
+            cells.get(i).setContents(amount == 0 ? kind.empty() : fluid, amount);
+        }
+    }
+
+    private long[] settle(F fluid, long totalDroplets) {
+        long[] capacities = new long[cells.size()];
+        for (int i = 0; i < cells.size(); i++) {
+            capacities[i] = cells.get(i).capacity();
+        }
+        return FluidColumn.settle(capacities, totalDroplets, kind.isGas(fluid));
+    }
+
+    /** Floors a non-negative {@code value} to a whole multiple of {@code quantum}. */
+    private static long floorTo(long value, long quantum) {
+        return value - (value % quantum);
+    }
+}

--- a/core/src/test/java/com/indemnity83/irontanks/core/TankColumnTest.java
+++ b/core/src/test/java/com/indemnity83/irontanks/core/TankColumnTest.java
@@ -122,6 +122,13 @@ class TankColumnTest {
     }
 
     @Test
+    void isPotionDelegatesToTheKind() {
+        TankColumn<FakeFluid> col = column(FakeCell.of(1000));
+        assertThat(col.isPotion(POTION)).isTrue();
+        assertThat(col.isPotion(WATER)).isFalse();
+    }
+
+    @Test
     void detectsMixedColumns() {
         assertThat(column(FakeCell.of(1000, WATER, 400), FakeCell.of(1000, LAVA, 400))
                         .mixed())
@@ -191,6 +198,13 @@ class TankColumnTest {
     }
 
     @Test
+    void insertIntoFullColumnMovesNothing() {
+        FakeCell a = FakeCell.of(1000, WATER, 1000);
+        assertThat(column(a).insert(WATER, 500, 1, IGNORE)).isZero();
+        assertThat(a.amount()).isEqualTo(1000);
+    }
+
+    @Test
     void creativeInsertDefinesSourceAndStaysFull() {
         FakeCell creative = new FakeCell(TankTier.CREATIVE, 1000, null, 0);
         long moved = column(creative).insert(WATER, 50 * MB, MB, IGNORE);
@@ -224,6 +238,29 @@ class TankColumnTest {
         assertThat(column(FakeCell.of(1000, POTION, 400)).extract(POTION, 100, 1, IGNORE))
                 .isZero();
         assertThat(column(FakeCell.of(1000)).extract(WATER, 100, 1, IGNORE)).isZero();
+    }
+
+    @Test
+    void extractIgnoresBlankAndNonPositive() {
+        assertThat(column(FakeCell.of(1000, WATER, 400)).extract(null, 100, 1, IGNORE))
+                .isZero();
+        assertThat(column(FakeCell.of(1000, WATER, 400)).extract(WATER, 0, 1, IGNORE))
+                .isZero();
+    }
+
+    @Test
+    void extractRejectsMixedColumn() {
+        assertThat(column(FakeCell.of(1000, WATER, 400), FakeCell.of(1000, LAVA, 400))
+                        .extract(WATER, 100, 1, IGNORE))
+                .isZero();
+    }
+
+    @Test
+    void extractMovesNothingBelowOneQuantum() {
+        // Less than a whole millibucket is present; a pipe draining in mB can take nothing.
+        FakeCell a = FakeCell.of(1000 * MB, WATER, 40);
+        assertThat(column(a).extract(WATER, 1000 * MB, MB, IGNORE)).isZero();
+        assertThat(a.amount()).isEqualTo(40);
     }
 
     @Test
@@ -271,6 +308,23 @@ class TankColumnTest {
         FakeCell a = FakeCell.of(1000 * MB, WATER, BOTTLE - 1);
         assertThat(column(a).extractBottle(WATER, IGNORE)).isFalse();
         assertThat(a.amount()).isEqualTo(BOTTLE - 1);
+    }
+
+    @Test
+    void depositBottleRejectsBlank() {
+        assertThat(column(FakeCell.of(1000 * MB)).depositBottle(null, IGNORE)).isFalse();
+    }
+
+    @Test
+    void extractBottleRejectsBlankMixedAndAbsent() {
+        assertThat(column(FakeCell.of(1000 * MB, WATER, BOTTLE)).extractBottle(null, IGNORE))
+                .isFalse();
+        assertThat(column(FakeCell.of(1000, WATER, 400), FakeCell.of(1000, LAVA, 400))
+                        .extractBottle(WATER, IGNORE))
+                .isFalse();
+        assertThat(column(FakeCell.of(1000 * MB)).extractBottle(WATER, IGNORE)).isFalse();
+        assertThat(column(FakeCell.of(1000 * MB, WATER, BOTTLE)).extractBottle(LAVA, IGNORE))
+                .isFalse();
     }
 
     @Test

--- a/core/src/test/java/com/indemnity83/irontanks/core/TankColumnTest.java
+++ b/core/src/test/java/com/indemnity83/irontanks/core/TankColumnTest.java
@@ -1,0 +1,325 @@
+package com.indemnity83.irontanks.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Exercises the column algorithm with tiny in-memory fakes, no Minecraft. A fluid is just an id plus
+ * gas/potion flags; a cell is a mutable capacity + contents. {@code null} is the empty fluid.
+ */
+class TankColumnTest {
+
+    private static final long MB = TankTier.DROPLETS_PER_MB; // 81 droplets
+    private static final long BOTTLE = TankTier.DROPLETS_PER_BOTTLE; // 27_000 droplets
+
+    private static final FakeFluid WATER = new FakeFluid("water", false, false);
+    private static final FakeFluid LAVA = new FakeFluid("lava", false, false);
+    private static final FakeFluid GAS = new FakeFluid("gas", true, false);
+    private static final FakeFluid POTION = new FakeFluid("potion", false, true);
+
+    private record FakeFluid(String id, boolean gas, boolean potion) {}
+
+    private static final class FakeKind implements FluidKind<FakeFluid> {
+        @Override
+        public FakeFluid empty() {
+            return null;
+        }
+
+        @Override
+        public boolean isEmpty(FakeFluid fluid) {
+            return fluid == null;
+        }
+
+        @Override
+        public boolean isGas(FakeFluid fluid) {
+            return fluid != null && fluid.gas();
+        }
+
+        @Override
+        public boolean isPotion(FakeFluid fluid) {
+            return fluid != null && fluid.potion();
+        }
+    }
+
+    private static final class FakeCell implements TankCell<FakeFluid> {
+        private final TankTier tier;
+        private final long capacity;
+        private FakeFluid fluid;
+        private long amount;
+
+        FakeCell(TankTier tier, long capacity, FakeFluid fluid, long amount) {
+            this.tier = tier;
+            this.capacity = capacity;
+            this.fluid = fluid;
+            this.amount = amount;
+        }
+
+        static FakeCell of(long capacity) {
+            return new FakeCell(TankTier.GLASS, capacity, null, 0);
+        }
+
+        static FakeCell of(long capacity, FakeFluid fluid, long amount) {
+            return new FakeCell(TankTier.GLASS, capacity, fluid, amount);
+        }
+
+        @Override
+        public TankTier tier() {
+            return tier;
+        }
+
+        @Override
+        public long capacity() {
+            return capacity;
+        }
+
+        @Override
+        public long amount() {
+            return amount;
+        }
+
+        @Override
+        public FakeFluid fluid() {
+            return fluid;
+        }
+
+        @Override
+        public void setContents(FakeFluid fluid, long amount) {
+            this.amount = Math.max(0, amount);
+            this.fluid = this.amount == 0 ? null : fluid;
+        }
+    }
+
+    /** Counts onMutate invocations so a test can assert "snapshot taken only when actually changing". */
+    private static final class MutateCounter implements Runnable {
+        int count;
+
+        @Override
+        public void run() {
+            count++;
+        }
+    }
+
+    private static final MutateCounter IGNORE = new MutateCounter();
+
+    private static TankColumn<FakeFluid> column(FakeCell... cells) {
+        List<FakeCell> list = new ArrayList<>(List.of(cells));
+        return new TankColumn<>(list.get(0), list, new FakeKind());
+    }
+
+    // ==================== aggregation ====================
+
+    @Test
+    void aggregatesTotalCapacityAndRoom() {
+        TankColumn<FakeFluid> col = column(FakeCell.of(1000, WATER, 400), FakeCell.of(1000), FakeCell.of(500));
+        assertThat(col.total()).isEqualTo(400);
+        assertThat(col.capacity()).isEqualTo(2500);
+        assertThat(col.room()).isEqualTo(2100);
+        assertThat(col.shared()).isEqualTo(WATER);
+        assertThat(col.mixed()).isFalse();
+    }
+
+    @Test
+    void detectsMixedColumns() {
+        assertThat(column(FakeCell.of(1000, WATER, 400), FakeCell.of(1000, LAVA, 400))
+                        .mixed())
+                .isTrue();
+        assertThat(column(FakeCell.of(1000, WATER, 400), FakeCell.of(1000, WATER, 400))
+                        .mixed())
+                .isFalse();
+    }
+
+    // ==================== insert ====================
+
+    @Test
+    void insertFillsEmptyColumnInDroplets() {
+        FakeCell a = FakeCell.of(1000);
+        FakeCell b = FakeCell.of(1000);
+        long moved = column(a, b).insert(WATER, 1500, 1, IGNORE);
+        assertThat(moved).isEqualTo(1500);
+        // liquid settles to the bottom (origin/first cell), then the next
+        assertThat(a.amount()).isEqualTo(1000);
+        assertThat(a.fluid()).isEqualTo(WATER);
+        assertThat(b.amount()).isEqualTo(500);
+    }
+
+    @Test
+    void insertCapsAtRoom() {
+        FakeCell a = FakeCell.of(1000, WATER, 800);
+        assertThat(column(a).insert(WATER, 5000, 1, IGNORE)).isEqualTo(200);
+        assertThat(a.amount()).isEqualTo(1000);
+    }
+
+    @Test
+    void insertFloorsToQuantumWhenRoomHasSubUnitRemainder() {
+        // One bottle (333.33 mB) sits in a 1000 mB tank; room is 666.66 mB. A pipe inserting whole
+        // millibuckets must take only 666 mB and leave the fractional remainder, never overfilling.
+        FakeCell a = FakeCell.of(1000 * MB, WATER, BOTTLE);
+        long moved = column(a).insert(WATER, 1000 * MB, MB, IGNORE);
+        assertThat(moved).isEqualTo(666 * MB);
+        assertThat(a.amount()).isEqualTo(BOTTLE + 666 * MB);
+        assertThat(a.amount()).isLessThan(a.capacity()); // 54-droplet remainder still free
+    }
+
+    @Test
+    void insertGasSettlesToTop() {
+        FakeCell a = FakeCell.of(1000);
+        FakeCell b = FakeCell.of(1000);
+        column(a, b).insert(GAS, 1500, 1, IGNORE);
+        assertThat(b.amount()).isEqualTo(1000); // top fills first for gas
+        assertThat(a.amount()).isEqualTo(500);
+    }
+
+    @Test
+    void insertRejectsMixedDifferentFluidAndPotions() {
+        assertThat(column(FakeCell.of(1000, WATER, 400), FakeCell.of(1000, LAVA, 400))
+                        .insert(WATER, 100, 1, IGNORE))
+                .isZero();
+        assertThat(column(FakeCell.of(1000, WATER, 400)).insert(LAVA, 100, 1, IGNORE))
+                .isZero();
+        assertThat(column(FakeCell.of(1000)).insert(POTION, 100, 1, IGNORE)).isZero();
+        assertThat(column(FakeCell.of(1000, POTION, 400)).insert(WATER, 100, 1, IGNORE))
+                .isZero();
+    }
+
+    @Test
+    void insertIgnoresBlankAndNonPositive() {
+        assertThat(column(FakeCell.of(1000)).insert(null, 100, 1, IGNORE)).isZero();
+        assertThat(column(FakeCell.of(1000)).insert(WATER, 0, 1, IGNORE)).isZero();
+    }
+
+    @Test
+    void creativeInsertDefinesSourceAndStaysFull() {
+        FakeCell creative = new FakeCell(TankTier.CREATIVE, 1000, null, 0);
+        long moved = column(creative).insert(WATER, 50 * MB, MB, IGNORE);
+        assertThat(moved).isEqualTo(50 * MB); // reports the full request honored
+        assertThat(creative.amount()).isEqualTo(1000); // and the tank is full
+        assertThat(creative.fluid()).isEqualTo(WATER);
+    }
+
+    // ==================== extract ====================
+
+    @Test
+    void extractDrainsAndCapsAtContents() {
+        FakeCell a = FakeCell.of(1000, WATER, 600);
+        assertThat(column(a).extract(WATER, 5000, 1, IGNORE)).isEqualTo(600);
+        assertThat(a.amount()).isZero();
+        assertThat(a.fluid()).isNull();
+    }
+
+    @Test
+    void extractFloorsToQuantum() {
+        FakeCell a = FakeCell.of(1000 * MB, WATER, BOTTLE); // 333.33 mB available
+        long moved = column(a).extract(WATER, 1000 * MB, MB, IGNORE);
+        assertThat(moved).isEqualTo(333 * MB);
+        assertThat(a.amount()).isEqualTo(BOTTLE - 333 * MB);
+    }
+
+    @Test
+    void extractRejectsMismatchPotionAndEmpty() {
+        assertThat(column(FakeCell.of(1000, WATER, 400)).extract(LAVA, 100, 1, IGNORE))
+                .isZero();
+        assertThat(column(FakeCell.of(1000, POTION, 400)).extract(POTION, 100, 1, IGNORE))
+                .isZero();
+        assertThat(column(FakeCell.of(1000)).extract(WATER, 100, 1, IGNORE)).isZero();
+    }
+
+    @Test
+    void creativeExtractIsEndless() {
+        FakeCell creative = new FakeCell(TankTier.CREATIVE, 1000, WATER, 1000);
+        assertThat(column(creative).extract(WATER, 50 * MB, MB, IGNORE)).isEqualTo(50 * MB);
+        assertThat(creative.amount()).isEqualTo(1000); // never depletes
+    }
+
+    // ==================== bottles (droplet-exact) ====================
+
+    @Test
+    void depositBottleAddsExactlyOneBottle() {
+        FakeCell a = FakeCell.of(1000 * MB);
+        assertThat(column(a).depositBottle(WATER, IGNORE)).isTrue();
+        assertThat(a.amount()).isEqualTo(BOTTLE);
+        assertThat(a.fluid()).isEqualTo(WATER);
+    }
+
+    @Test
+    void depositBottleFailsWithoutRoom() {
+        FakeCell a = FakeCell.of(BOTTLE - 1);
+        assertThat(column(a).depositBottle(WATER, IGNORE)).isFalse();
+        assertThat(a.amount()).isZero();
+    }
+
+    @Test
+    void depositBottleRejectsMixedAndDifferentFluid() {
+        assertThat(column(FakeCell.of(1000, WATER, 400)).depositBottle(LAVA, IGNORE))
+                .isFalse();
+        assertThat(column(FakeCell.of(1000, WATER, 400), FakeCell.of(1000, LAVA, 400))
+                        .depositBottle(WATER, IGNORE))
+                .isFalse();
+    }
+
+    @Test
+    void extractBottleDrawsExactlyOneBottle() {
+        FakeCell a = FakeCell.of(1000 * MB, WATER, BOTTLE);
+        assertThat(column(a).extractBottle(WATER, IGNORE)).isTrue();
+        assertThat(a.amount()).isZero();
+    }
+
+    @Test
+    void extractBottleFailsBelowABottle() {
+        FakeCell a = FakeCell.of(1000 * MB, WATER, BOTTLE - 1);
+        assertThat(column(a).extractBottle(WATER, IGNORE)).isFalse();
+        assertThat(a.amount()).isEqualTo(BOTTLE - 1);
+    }
+
+    @Test
+    void creativeBottlesAreEndlessAndDefining() {
+        FakeCell creative = new FakeCell(TankTier.CREATIVE, 1000, null, 0);
+        assertThat(column(creative).depositBottle(WATER, IGNORE)).isTrue();
+        assertThat(creative.amount()).isEqualTo(1000);
+        assertThat(column(creative).extractBottle(WATER, IGNORE)).isTrue();
+        assertThat(creative.amount()).isEqualTo(1000); // never depletes
+    }
+
+    // ==================== rebalance (settling path) ====================
+
+    @Test
+    void rebalanceSettlesLiquidDownAndReportsChangedCells() {
+        // Fluid sitting in the top tank should fall to the bottom.
+        FakeCell bottom = FakeCell.of(1000);
+        FakeCell top = FakeCell.of(1000, WATER, 600);
+        List<TankCell<FakeFluid>> changed = column(bottom, top).rebalance();
+        assertThat(bottom.amount()).isEqualTo(600);
+        assertThat(top.amount()).isZero();
+        assertThat(changed).containsExactlyInAnyOrder(bottom, top);
+    }
+
+    @Test
+    void rebalanceLeavesSettledColumnUnchanged() {
+        FakeCell bottom = FakeCell.of(1000, WATER, 1000);
+        FakeCell top = FakeCell.of(1000, WATER, 200);
+        assertThat(column(bottom, top).rebalance()).isEmpty();
+    }
+
+    @Test
+    void rebalanceLeavesMixedAndEmptyColumnsAlone() {
+        assertThat(column(FakeCell.of(1000, WATER, 400), FakeCell.of(1000, LAVA, 400))
+                        .rebalance())
+                .isEmpty();
+        assertThat(column(FakeCell.of(1000), FakeCell.of(1000)).rebalance()).isEmpty();
+    }
+
+    // ==================== onMutate hook ====================
+
+    @Test
+    void onMutateRunsOnlyWhenColumnActuallyChanges() {
+        MutateCounter counter = new MutateCounter();
+        // Rejected insert: no snapshot.
+        column(FakeCell.of(1000, WATER, 400)).insert(LAVA, 100, 1, counter);
+        assertThat(counter.count).isZero();
+        // Accepted insert: snapshot taken once.
+        column(FakeCell.of(1000)).insert(WATER, 100, 1, counter);
+        assertThat(counter.count).isEqualTo(1);
+    }
+}

--- a/core/src/test/java/com/indemnity83/irontanks/core/TankColumnTest.java
+++ b/core/src/test/java/com/indemnity83/irontanks/core/TankColumnTest.java
@@ -292,6 +292,14 @@ class TankColumnTest {
     }
 
     @Test
+    void depositBottleTopsUpTheSameFluid() {
+        FakeCell a = FakeCell.of(1000 * MB, WATER, BOTTLE);
+        assertThat(column(a).depositBottle(WATER, IGNORE)).isTrue();
+        assertThat(a.amount()).isEqualTo(2 * BOTTLE);
+        assertThat(a.fluid()).isEqualTo(WATER);
+    }
+
+    @Test
     void depositBottleFailsWithoutRoom() {
         FakeCell a = FakeCell.of(BOTTLE - 1);
         assertThat(column(a).depositBottle(WATER, IGNORE)).isFalse();
@@ -365,6 +373,17 @@ class TankColumnTest {
         FakeCell bottom = FakeCell.of(1000, WATER, 1000);
         FakeCell top = FakeCell.of(1000, WATER, 200);
         assertThat(column(bottom, top).rebalance()).isEmpty();
+    }
+
+    @Test
+    void rebalanceClearsAGhostFluidWhoseAmountIsAlreadyZero() {
+        // A cell that still names a fluid but holds nothing (amount 0) is inconsistent; rebalance
+        // normalises it to empty even though its amount already matches the settled target.
+        FakeCell ghost = new FakeCell(TankTier.GLASS, 1000, WATER, 0);
+        List<TankCell<FakeFluid>> changed = column(ghost).rebalance();
+        assertThat(ghost.amount()).isZero();
+        assertThat(ghost.fluid()).isNull();
+        assertThat(changed).containsExactly(ghost);
     }
 
     @Test

--- a/core/src/test/java/com/indemnity83/irontanks/core/TankColumnTest.java
+++ b/core/src/test/java/com/indemnity83/irontanks/core/TankColumnTest.java
@@ -1,6 +1,7 @@
 package com.indemnity83.irontanks.core;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -195,6 +196,16 @@ class TankColumnTest {
     void insertIgnoresBlankAndNonPositive() {
         assertThat(column(FakeCell.of(1000)).insert(null, 100, 1, IGNORE)).isZero();
         assertThat(column(FakeCell.of(1000)).insert(WATER, 0, 1, IGNORE)).isZero();
+    }
+
+    @Test
+    void insertAndExtractRejectNonPositiveQuantum() {
+        assertThatThrownBy(() -> column(FakeCell.of(1000)).insert(WATER, 100, 0, IGNORE))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("quantum");
+        assertThatThrownBy(() -> column(FakeCell.of(1000, WATER, 400)).extract(WATER, 100, -1, IGNORE))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("quantum");
     }
 
     @Test

--- a/fabric/src/main/java/com/indemnity83/irontanks/fabric/content/FluidVariantKind.java
+++ b/fabric/src/main/java/com/indemnity83/irontanks/fabric/content/FluidVariantKind.java
@@ -1,0 +1,34 @@
+package com.indemnity83.irontanks.fabric.content;
+
+import com.indemnity83.irontanks.core.FluidKind;
+import net.fabricmc.fabric.api.transfer.v1.fluid.FluidVariant;
+import net.fabricmc.fabric.api.transfer.v1.fluid.FluidVariantAttributes;
+import net.minecraft.core.component.DataComponents;
+
+/** Adapts Fabric's {@link FluidVariant} to the {@code core} {@link FluidKind} seam. */
+public final class FluidVariantKind implements FluidKind<FluidVariant> {
+
+    public static final FluidVariantKind INSTANCE = new FluidVariantKind();
+
+    private FluidVariantKind() {}
+
+    @Override
+    public FluidVariant empty() {
+        return FluidVariant.blank();
+    }
+
+    @Override
+    public boolean isEmpty(FluidVariant fluid) {
+        return fluid.isBlank();
+    }
+
+    @Override
+    public boolean isGas(FluidVariant fluid) {
+        return !fluid.isBlank() && FluidVariantAttributes.isLighterThanAir(fluid);
+    }
+
+    @Override
+    public boolean isPotion(FluidVariant fluid) {
+        return !fluid.isBlank() && fluid.get(DataComponents.POTION_CONTENTS) != null;
+    }
+}

--- a/fabric/src/main/java/com/indemnity83/irontanks/fabric/content/TankBlockEntity.java
+++ b/fabric/src/main/java/com/indemnity83/irontanks/fabric/content/TankBlockEntity.java
@@ -1,6 +1,7 @@
 package com.indemnity83.irontanks.fabric.content;
 
-import com.indemnity83.irontanks.core.FluidColumn;
+import com.indemnity83.irontanks.core.TankCell;
+import com.indemnity83.irontanks.core.TankColumn;
 import com.indemnity83.irontanks.core.TankTier;
 import com.indemnity83.irontanks.core.VoidTank;
 import java.util.ArrayDeque;
@@ -8,7 +9,6 @@ import java.util.ArrayList;
 import java.util.Deque;
 import java.util.List;
 import net.fabricmc.fabric.api.transfer.v1.fluid.FluidVariant;
-import net.fabricmc.fabric.api.transfer.v1.fluid.FluidVariantAttributes;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.HolderLookup;
@@ -27,11 +27,11 @@ import org.jetbrains.annotations.Nullable;
 /**
  * Stores a single fluid amount (in millibuckets, matching {@code core}) for one tank. Every connected
  * tank in a vertical column holds the same fluid, so a column's contents are a single total
- * redistributed by {@link FluidColumn}: liquids settle to the bottom, gases rise. Void tanks destroy
+ * redistributed by {@link TankColumn}: liquids settle to the bottom, gases rise. Void tanks destroy
  * their own contents each tick; creative tanks never join a column. Distribution math lives in
  * {@code core}; this is just the Fabric wiring.
  */
-public class TankBlockEntity extends BlockEntity {
+public class TankBlockEntity extends BlockEntity implements TankCell<FluidVariant> {
 
     private FluidVariant fluid = FluidVariant.blank();
     private long amount;
@@ -61,6 +61,23 @@ public class TankBlockEntity extends BlockEntity {
     public void setContentsRaw(FluidVariant fluid, long amount) {
         this.amount = Math.max(0, amount);
         this.fluid = this.amount == 0 ? FluidVariant.blank() : fluid;
+    }
+
+    // ---- TankCell<FluidVariant>: the core seam (tier/capacity/amount above already satisfy it) ----
+
+    @Override
+    public FluidVariant fluid() {
+        return fluid;
+    }
+
+    @Override
+    public void setContents(FluidVariant fluid, long amount) {
+        setContentsRaw(fluid, amount);
+    }
+
+    /** This tank's column as the loader-agnostic {@link TankColumn} the fluid algorithm runs on. */
+    public TankColumn<FluidVariant> asColumn() {
+        return new TankColumn<>(this, columnTanks(), FluidVariantKind.INSTANCE);
     }
 
     /** Persist + push this tile to clients (no rebalance). */
@@ -125,41 +142,11 @@ public class TankBlockEntity extends BlockEntity {
         if (level == null || level.isClientSide()) {
             return false;
         }
-        List<TankBlockEntity> column = column();
-        if (column.size() <= 1) {
-            return false;
+        List<TankCell<FluidVariant>> changed = asColumn().rebalance();
+        for (TankCell<FluidVariant> cell : changed) {
+            ((TankBlockEntity) cell).sync();
         }
-        FluidVariant shared = FluidVariant.blank();
-        long total = 0;
-        for (TankBlockEntity tank : column) {
-            if (tank.fluid.isBlank()) {
-                continue;
-            }
-            if (shared.isBlank()) {
-                shared = tank.fluid;
-            } else if (!shared.equals(tank.fluid)) {
-                return false; // mixed fluids: leave the column alone
-            }
-            total += tank.amount;
-        }
-        if (shared.isBlank()) {
-            return false;
-        }
-        long[] capacities = column.stream().mapToLong(TankBlockEntity::capacity).toArray();
-        boolean gas = FluidVariantAttributes.isLighterThanAir(shared);
-        long[] settled = FluidColumn.settle(capacities, total, gas);
-        boolean changed = false;
-        for (int i = 0; i < column.size(); i++) {
-            TankBlockEntity tank = column.get(i);
-            long target = settled[i];
-            FluidVariant targetFluid = target == 0 ? FluidVariant.blank() : shared;
-            if (tank.amount != target || !tank.fluid.equals(targetFluid)) {
-                tank.setContentsRaw(targetFluid, target);
-                tank.sync();
-                changed = true;
-            }
-        }
-        return changed;
+        return !changed.isEmpty();
     }
 
     /** This column, ordered bottom-to-top. Creative tanks never connect, so they stay isolated. */

--- a/fabric/src/main/java/com/indemnity83/irontanks/fabric/content/TankBlockEntity.java
+++ b/fabric/src/main/java/com/indemnity83/irontanks/fabric/content/TankBlockEntity.java
@@ -25,11 +25,12 @@ import net.minecraft.world.level.storage.ValueOutput;
 import org.jetbrains.annotations.Nullable;
 
 /**
- * Stores a single fluid amount (in millibuckets, matching {@code core}) for one tank. Every connected
- * tank in a vertical column holds the same fluid, so a column's contents are a single total
- * redistributed by {@link TankColumn}: liquids settle to the bottom, gases rise. Void tanks destroy
- * their own contents each tick; creative tanks never join a column. Distribution math lives in
- * {@code core}; this is just the Fabric wiring.
+ * Stores a single fluid amount (in droplets, the unit {@code core} uses and Fabric speaks natively) for
+ * one tank. Every connected tank in a vertical column holds the same fluid, so a column's contents are a
+ * single total redistributed by {@link TankColumn}: liquids settle to the bottom, gases rise. Void tanks
+ * destroy their own contents each tick; creative tanks never join a column. Distribution math lives in
+ * {@code core}; this is just the Fabric wiring. On disk the amount is saved as millibuckets plus a
+ * sub-mB droplet remainder (see {@link #saveAdditional}), converting via {@link TankTier#DROPLETS_PER_MB}.
  */
 public class TankBlockEntity extends BlockEntity implements TankCell<FluidVariant> {
 
@@ -44,7 +45,7 @@ public class TankBlockEntity extends BlockEntity implements TankCell<FluidVarian
         return getBlockState().getBlock() instanceof TankBlock tank ? tank.tier() : TankTier.GLASS;
     }
 
-    /** Capacity in millibuckets. */
+    /** Capacity in droplets. */
     public long capacity() {
         return tier().capacity();
     }

--- a/fabric/src/main/java/com/indemnity83/irontanks/fabric/content/TankFluidStorage.java
+++ b/fabric/src/main/java/com/indemnity83/irontanks/fabric/content/TankFluidStorage.java
@@ -1,27 +1,24 @@
 package com.indemnity83.irontanks.fabric.content;
 
-import com.indemnity83.irontanks.core.FluidColumn;
+import com.indemnity83.irontanks.core.TankColumn;
 import com.indemnity83.irontanks.core.TankTier;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import net.fabricmc.fabric.api.transfer.v1.fluid.FluidVariant;
-import net.fabricmc.fabric.api.transfer.v1.fluid.FluidVariantAttributes;
 import net.fabricmc.fabric.api.transfer.v1.storage.Storage;
 import net.fabricmc.fabric.api.transfer.v1.storage.StorageView;
 import net.fabricmc.fabric.api.transfer.v1.transaction.TransactionContext;
 import net.fabricmc.fabric.api.transfer.v1.transaction.base.SnapshotParticipant;
-import net.minecraft.core.component.DataComponents;
 
 /**
  * Exposes a whole vertical tank column to Fabric's Transfer API as one {@link Storage}{@code
- * <FluidVariant>}. Operations act on the column's combined contents and re-settle them via {@code
- * core}, so filling any tank in a stack fills the column. A creative tank never joins a column, so it
- * acts as a single endless source/sink.
+ * <FluidVariant>}. The fluid algorithm — mixed-fluid refusal, potion sealing, creative source/sink,
+ * settling — lives in {@code core}'s {@link TankColumn}; this class is just the Fabric surface plus a
+ * transaction snapshot.
  *
- * <p>Fabric measures fluid in droplets, which is exactly the unit {@code core} and the tank store (see
- * {@link TankTier}). So unlike the NeoForge adapter, this one needs no unit conversion — it is native
- * droplets throughout.
+ * <p>Fabric measures fluid in droplets, exactly the unit {@code core} uses, so insert/extract pass a
+ * quantum of {@code 1} (no flooring) — unlike the NeoForge adapter, this one needs no unit conversion.
  */
 public final class TankFluidStorage extends SnapshotParticipant<TankFluidStorage.Snapshot>
         implements Storage<FluidVariant> {
@@ -37,70 +34,18 @@ public final class TankFluidStorage extends SnapshotParticipant<TankFluidStorage
         this.origin = origin;
     }
 
-    private boolean creative() {
-        return origin.tier() == TankTier.CREATIVE;
-    }
-
-    private List<TankBlockEntity> column() {
-        return origin.columnTanks();
+    private TankColumn<FluidVariant> column() {
+        return origin.asColumn();
     }
 
     @Override
     public long insert(FluidVariant resource, long maxAmount, TransactionContext transaction) {
-        if (resource.isBlank() || maxAmount <= 0) {
-            return 0;
-        }
-        List<TankBlockEntity> column = column();
-        if (mixed(column)) {
-            return 0; // distinct fluids joined into one column: leave them alone, never aggregate
-        }
-        FluidVariant current = shared(column);
-        if (isPotion(current) || isPotion(resource)) {
-            return 0; // sealed: potions are deposited only via depositBottle
-        }
-        if (!current.isBlank() && !current.equals(resource)) {
-            return 0;
-        }
-        if (creative()) {
-            updateSnapshots(transaction);
-            origin.setContentsRaw(resource, origin.capacity());
-            return maxAmount;
-        }
-        long room = FluidColumn.fillable(capacityDroplets(column), totalDroplets(column), maxAmount);
-        if (room <= 0) {
-            return 0;
-        }
-        updateSnapshots(transaction);
-        distribute(column, resource, totalDroplets(column) + room);
-        return room;
+        return column().insert(resource, maxAmount, 1, () -> updateSnapshots(transaction));
     }
 
     @Override
     public long extract(FluidVariant resource, long maxAmount, TransactionContext transaction) {
-        if (resource.isBlank() || maxAmount <= 0) {
-            return 0;
-        }
-        List<TankBlockEntity> column = column();
-        if (mixed(column)) {
-            return 0; // distinct fluids joined into one column: leave them alone, never aggregate
-        }
-        FluidVariant current = shared(column);
-        if (isPotion(current)) {
-            return 0; // sealed: potions are drawn only via extractBottle
-        }
-        if (current.isBlank() || !current.equals(resource)) {
-            return 0;
-        }
-        if (creative()) {
-            return maxAmount; // endless supply: never depletes
-        }
-        long taken = FluidColumn.drainable(totalDroplets(column), maxAmount);
-        if (taken <= 0) {
-            return 0;
-        }
-        updateSnapshots(transaction);
-        distribute(column, current, totalDroplets(column) - taken);
-        return taken;
+        return column().extract(resource, maxAmount, 1, () -> updateSnapshots(transaction));
     }
 
     /**
@@ -108,7 +53,7 @@ public final class TankFluidStorage extends SnapshotParticipant<TankFluidStorage
      * not hidden, so the bottle interaction can see and draw a potion that the fluid API hides from pipes.
      */
     public FluidVariant currentFluid() {
-        return shared(column());
+        return column().shared();
     }
 
     /**
@@ -116,52 +61,12 @@ public final class TankFluidStorage extends SnapshotParticipant<TankFluidStorage
      * resource} into the column, all-or-nothing. Returns whether a full bottle fit.
      */
     public boolean depositBottle(FluidVariant resource, TransactionContext transaction) {
-        if (resource.isBlank()) {
-            return false;
-        }
-        List<TankBlockEntity> column = column();
-        if (mixed(column)) {
-            return false; // distinct fluids joined into one column: leave them alone
-        }
-        FluidVariant current = shared(column);
-        if (!current.isBlank() && !current.equals(resource)) {
-            return false;
-        }
-        if (creative()) {
-            updateSnapshots(transaction);
-            origin.setContentsRaw(resource, origin.capacity());
-            return true;
-        }
-        if (capacityDroplets(column) - totalDroplets(column) < TankTier.DROPLETS_PER_BOTTLE) {
-            return false;
-        }
-        updateSnapshots(transaction);
-        distribute(column, resource, totalDroplets(column) + TankTier.DROPLETS_PER_BOTTLE);
-        return true;
+        return column().depositBottle(resource, () -> updateSnapshots(transaction));
     }
 
     /** Draws exactly one bottle of {@code resource} out of the column, all-or-nothing. */
     public boolean extractBottle(FluidVariant resource, TransactionContext transaction) {
-        if (resource.isBlank()) {
-            return false;
-        }
-        List<TankBlockEntity> column = column();
-        if (mixed(column)) {
-            return false; // distinct fluids joined into one column: leave them alone
-        }
-        FluidVariant current = shared(column);
-        if (current.isBlank() || !current.equals(resource)) {
-            return false;
-        }
-        if (creative()) {
-            return true; // endless supply: never depletes
-        }
-        if (totalDroplets(column) < TankTier.DROPLETS_PER_BOTTLE) {
-            return false;
-        }
-        updateSnapshots(transaction);
-        distribute(column, current, totalDroplets(column) - TankTier.DROPLETS_PER_BOTTLE);
-        return true;
+        return column().extractBottle(resource, () -> updateSnapshots(transaction));
     }
 
     @Override
@@ -184,91 +89,28 @@ public final class TankFluidStorage extends SnapshotParticipant<TankFluidStorage
         @Override
         public FluidVariant getResource() {
             // A stored potion is bottle-only: present the tank as blank so pipes/pumps can't drain it.
-            FluidVariant current = shared(column());
-            return isPotion(current) ? FluidVariant.blank() : current;
+            TankColumn<FluidVariant> column = column();
+            FluidVariant current = column.shared();
+            return column.isPotion(current) ? FluidVariant.blank() : current;
         }
 
         @Override
         public long getAmount() {
-            return isPotion(shared(column())) ? 0 : totalDroplets(column());
+            TankColumn<FluidVariant> column = column();
+            return column.isPotion(column.shared()) ? 0 : column.total();
         }
 
         @Override
         public long getCapacity() {
-            return isPotion(shared(column())) ? 0 : capacityDroplets(column());
+            TankColumn<FluidVariant> column = column();
+            return column.isPotion(column.shared()) ? 0 : column.capacity();
         }
-    }
-
-    private static long totalDroplets(List<TankBlockEntity> column) {
-        long total = 0;
-        for (TankBlockEntity tank : column) {
-            total += tank.amount();
-        }
-        return total;
-    }
-
-    private static long capacityDroplets(List<TankBlockEntity> column) {
-        long capacity = 0;
-        for (TankBlockEntity tank : column) {
-            capacity += tank.capacity();
-        }
-        return capacity;
-    }
-
-    private static void distribute(List<TankBlockEntity> column, FluidVariant fluid, long totalDroplets) {
-        long[] capacities = column.stream().mapToLong(TankBlockEntity::capacity).toArray();
-        boolean gas = FluidVariantAttributes.isLighterThanAir(fluid);
-        long[] settled = FluidColumn.settle(capacities, totalDroplets, gas);
-        for (int i = 0; i < column.size(); i++) {
-            long amount = settled[i];
-            column.get(i).setContentsRaw(amount == 0 ? FluidVariant.blank() : fluid, amount);
-        }
-    }
-
-    /**
-     * Whether a fluid is a stored potion — water carrying a {@code potion_contents} component. Potions
-     * are bottle-only: this adapter hides them from pipes/pumps so a potion can never be drained out (and
-     * silently degraded to water) or topped up through the fluid API. Bottle I/O bypasses these methods.
-     */
-    private static boolean isPotion(FluidVariant fluid) {
-        return !fluid.isBlank() && fluid.get(DataComponents.POTION_CONTENTS) != null;
-    }
-
-    private static FluidVariant shared(List<TankBlockEntity> column) {
-        for (TankBlockEntity tank : column) {
-            if (!tank.fluidVariant().isBlank()) {
-                return tank.fluidVariant();
-            }
-        }
-        return FluidVariant.blank();
-    }
-
-    /**
-     * Whether the column holds two or more distinct fluids — e.g. two pre-filled tanks joined by a third.
-     * {@link #shared(List)} only reports the first one, so the fluid API would otherwise sum the whole
-     * column and redistribute it as that single fluid, converting the others. Operations refuse to act on
-     * such a column, mirroring {@link TankBlockEntity#balanceColumn()}, which leaves it unsettled.
-     */
-    private static boolean mixed(List<TankBlockEntity> column) {
-        FluidVariant seen = FluidVariant.blank();
-        for (TankBlockEntity tank : column) {
-            FluidVariant fluid = tank.fluidVariant();
-            if (fluid.isBlank()) {
-                continue;
-            }
-            if (seen.isBlank()) {
-                seen = fluid;
-            } else if (!seen.equals(fluid)) {
-                return true;
-            }
-        }
-        return false;
     }
 
     @Override
     protected Snapshot createSnapshot() {
         List<Slot> slots = new ArrayList<>();
-        for (TankBlockEntity tank : column()) {
+        for (TankBlockEntity tank : origin.columnTanks()) {
             slots.add(new Slot(tank, tank.fluidVariant(), tank.amount()));
         }
         return new Snapshot(slots);
@@ -283,8 +125,8 @@ public final class TankFluidStorage extends SnapshotParticipant<TankFluidStorage
 
     @Override
     protected void onFinalCommit() {
-        // Contents are already settled by distribute(); push every tank in the column to clients.
-        for (TankBlockEntity tank : column()) {
+        // Contents are already settled by the column; push every tank in it to clients.
+        for (TankBlockEntity tank : origin.columnTanks()) {
             tank.sync();
         }
     }

--- a/neoforge/src/main/java/com/indemnity83/irontanks/neoforge/content/FluidResourceKind.java
+++ b/neoforge/src/main/java/com/indemnity83/irontanks/neoforge/content/FluidResourceKind.java
@@ -1,0 +1,33 @@
+package com.indemnity83.irontanks.neoforge.content;
+
+import com.indemnity83.irontanks.core.FluidKind;
+import net.minecraft.core.component.DataComponents;
+import net.neoforged.neoforge.transfer.fluid.FluidResource;
+
+/** Adapts NeoForge's {@link FluidResource} to the {@code core} {@link FluidKind} seam. */
+public final class FluidResourceKind implements FluidKind<FluidResource> {
+
+    public static final FluidResourceKind INSTANCE = new FluidResourceKind();
+
+    private FluidResourceKind() {}
+
+    @Override
+    public FluidResource empty() {
+        return FluidResource.EMPTY;
+    }
+
+    @Override
+    public boolean isEmpty(FluidResource fluid) {
+        return fluid.isEmpty();
+    }
+
+    @Override
+    public boolean isGas(FluidResource fluid) {
+        return !fluid.isEmpty() && fluid.value().getFluidType().isLighterThanAir();
+    }
+
+    @Override
+    public boolean isPotion(FluidResource fluid) {
+        return !fluid.isEmpty() && fluid.get(DataComponents.POTION_CONTENTS) != null;
+    }
+}

--- a/neoforge/src/main/java/com/indemnity83/irontanks/neoforge/content/TankBlockEntity.java
+++ b/neoforge/src/main/java/com/indemnity83/irontanks/neoforge/content/TankBlockEntity.java
@@ -1,6 +1,7 @@
 package com.indemnity83.irontanks.neoforge.content;
 
-import com.indemnity83.irontanks.core.FluidColumn;
+import com.indemnity83.irontanks.core.TankCell;
+import com.indemnity83.irontanks.core.TankColumn;
 import com.indemnity83.irontanks.core.TankTier;
 import com.indemnity83.irontanks.core.VoidTank;
 import java.util.ArrayDeque;
@@ -24,11 +25,11 @@ import org.jetbrains.annotations.Nullable;
 
 /**
  * Stores a single fluid amount for one tank. Every connected tank in a vertical column holds the same
- * fluid, so a column's contents are a single total redistributed by {@link FluidColumn}: liquids settle
+ * fluid, so a column's contents are a single total redistributed by {@link TankColumn}: liquids settle
  * to the bottom, gases rise. Void tanks destroy their own contents each tick; creative tanks never join
  * a column. All distribution math lives in {@code core}; this class is just the Minecraft wiring.
  */
-public class TankBlockEntity extends BlockEntity {
+public class TankBlockEntity extends BlockEntity implements TankCell<FluidResource> {
 
     private FluidResource fluid = FluidResource.EMPTY;
     private long amount;
@@ -57,6 +58,23 @@ public class TankBlockEntity extends BlockEntity {
     public void setContentsRaw(FluidResource fluid, long amount) {
         this.amount = Math.max(0, amount);
         this.fluid = this.amount == 0 ? FluidResource.EMPTY : fluid;
+    }
+
+    // ---- TankCell<FluidResource>: the core seam (tier/capacity/amount above already satisfy it) ----
+
+    @Override
+    public FluidResource fluid() {
+        return fluid;
+    }
+
+    @Override
+    public void setContents(FluidResource fluid, long amount) {
+        setContentsRaw(fluid, amount);
+    }
+
+    /** This tank's column as the loader-agnostic {@link TankColumn} the fluid algorithm runs on. */
+    public TankColumn<FluidResource> asColumn() {
+        return new TankColumn<>(this, columnTanks(), FluidResourceKind.INSTANCE);
     }
 
     /** Persist + push this tile to clients (no rebalance). */
@@ -125,45 +143,11 @@ public class TankBlockEntity extends BlockEntity {
         if (level == null || level.isClientSide()) {
             return false;
         }
-        List<TankBlockEntity> column = column();
-        if (column.size() <= 1) {
-            return false;
+        List<TankCell<FluidResource>> changed = asColumn().rebalance();
+        for (TankCell<FluidResource> cell : changed) {
+            ((TankBlockEntity) cell).sync();
         }
-        FluidResource shared = FluidResource.EMPTY;
-        long total = 0;
-        for (TankBlockEntity tank : column) {
-            if (tank.fluid.isEmpty()) {
-                continue;
-            }
-            if (shared.isEmpty()) {
-                shared = tank.fluid;
-            } else if (!shared.equals(tank.fluid)) {
-                return false; // mixed fluids: leave the column alone
-            }
-            total += tank.amount;
-        }
-        if (shared.isEmpty()) {
-            return false;
-        }
-        long[] capacities = column.stream().mapToLong(TankBlockEntity::capacity).toArray();
-        boolean gas = shared.value().getFluidType().isLighterThanAir();
-        long[] settled = FluidColumn.settle(capacities, total, gas);
-        boolean changed = false;
-        for (int i = 0; i < column.size(); i++) {
-            TankBlockEntity tank = column.get(i);
-            long target = settled[i];
-            FluidResource targetFluid = target == 0 ? FluidResource.EMPTY : shared;
-            if (tank.amount != target || !tank.fluid.equals(targetFluid)) {
-                tank.setContentsRaw(targetFluid, target);
-                tank.setChanged();
-                if (level != null && !level.isClientSide()) {
-                    level.sendBlockUpdated(
-                            tank.worldPosition, tank.getBlockState(), tank.getBlockState(), Block.UPDATE_ALL);
-                }
-                changed = true;
-            }
-        }
-        return changed;
+        return !changed.isEmpty();
     }
 
     /** This column, ordered bottom-to-top. Creative tanks never connect, so they stay isolated. */

--- a/neoforge/src/main/java/com/indemnity83/irontanks/neoforge/content/TankFluidHandler.java
+++ b/neoforge/src/main/java/com/indemnity83/irontanks/neoforge/content/TankFluidHandler.java
@@ -1,10 +1,9 @@
 package com.indemnity83.irontanks.neoforge.content;
 
-import com.indemnity83.irontanks.core.FluidColumn;
+import com.indemnity83.irontanks.core.TankColumn;
 import com.indemnity83.irontanks.core.TankTier;
 import java.util.ArrayList;
 import java.util.List;
-import net.minecraft.core.component.DataComponents;
 import net.neoforged.neoforge.transfer.ResourceHandler;
 import net.neoforged.neoforge.transfer.fluid.FluidResource;
 import net.neoforged.neoforge.transfer.transaction.SnapshotJournal;
@@ -12,10 +11,11 @@ import net.neoforged.neoforge.transfer.transaction.TransactionContext;
 
 /**
  * Exposes a whole vertical tank column to NeoForge's transfer API as one single-slot {@link
- * ResourceHandler}. Inserting or extracting through any tank in a stack affects the column's combined
- * contents and re-settles them (liquids to the bottom, gases to the top) via {@code core}. This is why
- * filling the bottom of a full-bottom/empty-top stack still works — the room is in the column, not the
- * clicked tank. A creative tank never joins a column, so it acts as a single endless source/sink.
+ * ResourceHandler}. The fluid algorithm — mixed-fluid refusal, potion sealing, creative source/sink,
+ * settling — lives in {@code core}'s {@link TankColumn}; this class is just the NeoForge surface plus a
+ * transaction snapshot. The transfer API speaks millibuckets while {@code core} works in droplets, so
+ * insert/extract pass {@link TankTier#DROPLETS_PER_MB} as the column's quantum (flooring to whole mB)
+ * and convert the droplet result back; bottles stay droplet-exact.
  */
 public final class TankFluidHandler extends SnapshotJournal<TankFluidHandler.Snapshot>
         implements ResourceHandler<FluidResource> {
@@ -31,12 +31,8 @@ public final class TankFluidHandler extends SnapshotJournal<TankFluidHandler.Sna
         this.origin = origin;
     }
 
-    private boolean creative() {
-        return origin.tier() == TankTier.CREATIVE;
-    }
-
-    private List<TankBlockEntity> column() {
-        return origin.columnTanks();
+    private TankColumn<FluidResource> column() {
+        return origin.asColumn();
     }
 
     @Override
@@ -47,35 +43,39 @@ public final class TankFluidHandler extends SnapshotJournal<TankFluidHandler.Sna
     @Override
     public FluidResource getResource(int index) {
         checkIndex(index);
-        FluidResource current = shared(column());
+        TankColumn<FluidResource> column = column();
+        FluidResource current = column.shared();
         // A stored potion is bottle-only: hide it from the fluid API so pipes/buckets can't drain it.
-        return isPotion(current) ? FluidResource.EMPTY : current;
+        return column.isPotion(current) ? FluidResource.EMPTY : current;
     }
 
     @Override
     public long getAmountAsLong(int index) {
         checkIndex(index);
-        if (isPotion(shared(column()))) {
+        TankColumn<FluidResource> column = column();
+        if (column.isPotion(column.shared())) {
             return 0; // potion is bottle-only: report empty to the fluid API
         }
         // The column stores droplets; the NeoForge transfer API speaks millibuckets.
-        return totalDroplets(column()) / TankTier.DROPLETS_PER_MB;
+        return column.total() / TankTier.DROPLETS_PER_MB;
     }
 
     @Override
     public long getCapacityAsLong(int index, FluidResource resource) {
         checkIndex(index);
-        if (isPotion(shared(column()))) {
+        TankColumn<FluidResource> column = column();
+        if (column.isPotion(column.shared())) {
             return 0; // sealed while holding a potion
         }
-        return capacityDroplets(column()) / TankTier.DROPLETS_PER_MB;
+        return column.capacity() / TankTier.DROPLETS_PER_MB;
     }
 
     @Override
     public boolean isValid(int index, FluidResource resource) {
         checkIndex(index);
-        FluidResource current = shared(column());
-        if (isPotion(current) || isPotion(resource)) {
+        TankColumn<FluidResource> column = column();
+        FluidResource current = column.shared();
+        if (column.isPotion(current) || column.isPotion(resource)) {
             return false; // potions never move through the fluid API
         }
         return current.isEmpty() || current.equals(resource);
@@ -84,65 +84,23 @@ public final class TankFluidHandler extends SnapshotJournal<TankFluidHandler.Sna
     @Override
     public int insert(int index, FluidResource resource, int amountMb, TransactionContext transaction) {
         checkIndex(index);
-        if (resource.isEmpty() || amountMb <= 0) {
-            return 0;
-        }
-        List<TankBlockEntity> column = column();
-        if (mixed(column)) {
-            return 0; // distinct fluids joined into one column: leave them alone, never aggregate
-        }
-        FluidResource current = shared(column);
-        if (isPotion(current) || isPotion(resource)) {
-            return 0; // sealed: potions are deposited only via depositBottle
-        }
-        if (!current.isEmpty() && !current.equals(resource)) {
-            return 0;
-        }
-        if (creative()) {
-            updateSnapshots(transaction);
-            origin.setContentsRaw(resource, origin.capacity()); // define the source, stay full
-            return amountMb;
-        }
-        // Only whole millibuckets cross this boundary: floor the room so an existing sub-mB bottle
-        // fraction is never partially filled (which would create fluid against the pipe's mB accounting).
-        long roomMb = roomDroplets(column) / TankTier.DROPLETS_PER_MB;
-        long take = Math.min(amountMb, roomMb);
-        if (take <= 0) {
-            return 0;
-        }
-        updateSnapshots(transaction);
-        distribute(column, resource, totalDroplets(column) + take * TankTier.DROPLETS_PER_MB);
-        return (int) take;
+        long moved = column().insert(
+                        resource,
+                        (long) amountMb * TankTier.DROPLETS_PER_MB,
+                        TankTier.DROPLETS_PER_MB,
+                        () -> updateSnapshots(transaction));
+        return (int) (moved / TankTier.DROPLETS_PER_MB);
     }
 
     @Override
     public int extract(int index, FluidResource resource, int amountMb, TransactionContext transaction) {
         checkIndex(index);
-        if (resource.isEmpty() || amountMb <= 0) {
-            return 0;
-        }
-        List<TankBlockEntity> column = column();
-        if (mixed(column)) {
-            return 0; // distinct fluids joined into one column: leave them alone, never aggregate
-        }
-        FluidResource current = shared(column);
-        if (isPotion(current)) {
-            return 0; // sealed: potions are drawn only via extractBottle
-        }
-        if (current.isEmpty() || !current.equals(resource)) {
-            return 0;
-        }
-        if (creative()) {
-            return amountMb; // endless supply: never depletes
-        }
-        long availMb = totalDroplets(column) / TankTier.DROPLETS_PER_MB;
-        long take = Math.min(amountMb, availMb);
-        if (take <= 0) {
-            return 0;
-        }
-        updateSnapshots(transaction);
-        distribute(column, current, totalDroplets(column) - take * TankTier.DROPLETS_PER_MB);
-        return (int) take;
+        long moved = column().extract(
+                        resource,
+                        (long) amountMb * TankTier.DROPLETS_PER_MB,
+                        TankTier.DROPLETS_PER_MB,
+                        () -> updateSnapshots(transaction));
+        return (int) (moved / TankTier.DROPLETS_PER_MB);
     }
 
     /**
@@ -150,7 +108,7 @@ public final class TankFluidHandler extends SnapshotJournal<TankFluidHandler.Sna
      * sealed, so the bottle interaction can see and draw a potion that the fluid API hides from pipes.
      */
     public FluidResource currentFluid() {
-        return shared(column());
+        return column().shared();
     }
 
     /**
@@ -159,28 +117,7 @@ public final class TankFluidHandler extends SnapshotJournal<TankFluidHandler.Sna
      * whole-mB quantization of {@link #insert}. Returns whether a full bottle fit.
      */
     public boolean depositBottle(FluidResource resource, TransactionContext transaction) {
-        if (resource.isEmpty()) {
-            return false;
-        }
-        List<TankBlockEntity> column = column();
-        if (mixed(column)) {
-            return false; // distinct fluids joined into one column: leave them alone
-        }
-        FluidResource current = shared(column);
-        if (!current.isEmpty() && !current.equals(resource)) {
-            return false;
-        }
-        if (creative()) {
-            updateSnapshots(transaction);
-            origin.setContentsRaw(resource, origin.capacity());
-            return true;
-        }
-        if (roomDroplets(column) < TankTier.DROPLETS_PER_BOTTLE) {
-            return false;
-        }
-        updateSnapshots(transaction);
-        distribute(column, resource, totalDroplets(column) + TankTier.DROPLETS_PER_BOTTLE);
-        return true;
+        return column().depositBottle(resource, () -> updateSnapshots(transaction));
     }
 
     /**
@@ -188,104 +125,13 @@ public final class TankFluidHandler extends SnapshotJournal<TankFluidHandler.Sna
      * full bottle was present.
      */
     public boolean extractBottle(FluidResource resource, TransactionContext transaction) {
-        if (resource.isEmpty()) {
-            return false;
-        }
-        List<TankBlockEntity> column = column();
-        if (mixed(column)) {
-            return false; // distinct fluids joined into one column: leave them alone
-        }
-        FluidResource current = shared(column);
-        if (current.isEmpty() || !current.equals(resource)) {
-            return false;
-        }
-        if (creative()) {
-            return true; // endless supply: never depletes
-        }
-        if (totalDroplets(column) < TankTier.DROPLETS_PER_BOTTLE) {
-            return false;
-        }
-        updateSnapshots(transaction);
-        distribute(column, current, totalDroplets(column) - TankTier.DROPLETS_PER_BOTTLE);
-        return true;
-    }
-
-    private static long totalDroplets(List<TankBlockEntity> column) {
-        long total = 0;
-        for (TankBlockEntity tank : column) {
-            total += tank.amount();
-        }
-        return total;
-    }
-
-    private static long capacityDroplets(List<TankBlockEntity> column) {
-        long capacity = 0;
-        for (TankBlockEntity tank : column) {
-            capacity += tank.capacity();
-        }
-        return capacity;
-    }
-
-    private static long roomDroplets(List<TankBlockEntity> column) {
-        return capacityDroplets(column) - totalDroplets(column);
-    }
-
-    /** Settles {@code total} droplets across the column (via {@code core}) and writes each tank's share. */
-    private static void distribute(List<TankBlockEntity> column, FluidResource fluid, long total) {
-        long[] capacities = column.stream().mapToLong(TankBlockEntity::capacity).toArray();
-        boolean gas = fluid.value().getFluidType().isLighterThanAir();
-        long[] settled = FluidColumn.settle(capacities, total, gas);
-        for (int i = 0; i < column.size(); i++) {
-            long amount = settled[i];
-            column.get(i).setContentsRaw(amount == 0 ? FluidResource.EMPTY : fluid, amount);
-        }
-    }
-
-    /** The single fluid the column holds, or empty if the column is empty. */
-    private static FluidResource shared(List<TankBlockEntity> column) {
-        for (TankBlockEntity tank : column) {
-            if (!tank.fluidResource().isEmpty()) {
-                return tank.fluidResource();
-            }
-        }
-        return FluidResource.EMPTY;
-    }
-
-    /**
-     * Whether the column holds two or more distinct fluids — e.g. two pre-filled tanks joined by a third.
-     * {@link #shared(List)} only reports the first one, so the fluid API would otherwise sum the whole
-     * column and redistribute it as that single fluid, converting the others. Operations refuse to act on
-     * such a column, mirroring {@link TankBlockEntity#balanceColumn()}, which leaves it unsettled.
-     */
-    private static boolean mixed(List<TankBlockEntity> column) {
-        FluidResource seen = FluidResource.EMPTY;
-        for (TankBlockEntity tank : column) {
-            FluidResource fluid = tank.fluidResource();
-            if (fluid.isEmpty()) {
-                continue;
-            }
-            if (seen.isEmpty()) {
-                seen = fluid;
-            } else if (!seen.equals(fluid)) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    /**
-     * Whether a fluid is a stored potion — water carrying a {@code potion_contents} component. Potions
-     * are bottle-only: this adapter hides them from pipes/pumps so a potion can never be drained out (and
-     * silently degraded to water) or topped up through the fluid API. Bottle I/O bypasses these methods.
-     */
-    private static boolean isPotion(FluidResource fluid) {
-        return !fluid.isEmpty() && fluid.get(DataComponents.POTION_CONTENTS) != null;
+        return column().extractBottle(resource, () -> updateSnapshots(transaction));
     }
 
     @Override
     protected Snapshot createSnapshot() {
         List<Slot> slots = new ArrayList<>();
-        for (TankBlockEntity tank : column()) {
+        for (TankBlockEntity tank : origin.columnTanks()) {
             slots.add(new Slot(tank, tank.fluidResource(), tank.amount()));
         }
         return new Snapshot(slots);
@@ -300,7 +146,7 @@ public final class TankFluidHandler extends SnapshotJournal<TankFluidHandler.Sna
 
     @Override
     protected void onRootCommit(Snapshot originalState) {
-        // Sync every tank touched this transaction (contents are already settled by distribute()).
+        // Sync every tank touched this transaction (contents are already settled by the column).
         for (Slot slot : originalState.slots()) {
             slot.tank().sync();
         }


### PR DESCRIPTION
## Summary

Both loaders carried a near-verbatim copy of the same tank fluid logic — NeoForge's `TankFluidHandler` and Fabric's `TankFluidStorage` (~200 lines each), plus a duplicated `balanceColumn()` in each `TankBlockEntity`. This pulls that shared game logic into `core`, where it's owned once and unit-tested, leaving each loader with only its transfer-API surface.

No player-facing behavior changes — this is an internal restructure.

## Changes

- **New `core` seam:** `FluidKind<F>` (isEmpty/isGas/isPotion), `TankCell<F>` (tier/capacity/amount/fluid/setContents), and `TankColumn<F>` — the whole column algorithm (insert, extract, exact bottle deposit/withdraw, mixed-fluid refusal, potion sealing, creative source/sink, settling) in droplets, with no Minecraft on the classpath.
- **The NeoForge↔Fabric unit difference becomes a `quantum` parameter** rather than two copies: Fabric passes `1` (native droplets), NeoForge passes `DROPLETS_PER_MB` so insert/extract still floor to whole millibuckets exactly as before; bottles stay droplet-exact.
- **Each loader** now implements `TankCell` on its `TankBlockEntity` and provides a one-class `FluidKind` adapter; the fluid handler and `balanceColumn()` delegate to `TankColumn`. ~450 lines of duplicated glue removed.
- **New `TankColumnTest`** covers the rules that previously lived (untested) in the loaders — quantum flooring, bottle exactness, mixed/potion/creative handling, and settling. `core` `TankColumn` lands at 96% instruction coverage.

## Notes

- The transaction wrappers stay per-loader (NeoForge `SnapshotJournal` vs Fabric `SnapshotParticipant`); a small `onMutate` hook lets each capture its snapshot only when the column actually changes — preserving the existing no-op semantics.
- Verified: `:core:test`, `:core:jacocoTestReport`, `spotlessCheck`, and a full `build` (both loader jars, all source sets) all green.