### PR TITLE
fix: restore German, Spanish, Portuguese, Russian, Chinese and Pirate translations

### DIFF
--- a/resources/assets/irontanks/lang/de_de.json
+++ b/resources/assets/irontanks/lang/de_de.json
@@ -13,5 +13,5 @@
   "item.irontanks.silver_gold_upgrade": "Silber zu Goldbehälter Upgrade",
   "item.irontanks.gold_diamond_upgrade": "Gold zu Diamantbehälter Upgrade",
   "item.irontanks.diamond_obsidian_upgrade": "Diamant zu Obsidiantbehälter Upgrade",
-  "irontanks.tooltip.capacity": "hält %s eimer"
+  "irontanks.tooltip.capacity": "hält %s Eimer"
 }

--- a/resources/assets/irontanks/lang/de_de.json
+++ b/resources/assets/irontanks/lang/de_de.json
@@ -1,0 +1,17 @@
+{
+  "block.irontanks.copper_tank": "Kupferbehälter",
+  "block.irontanks.iron_tank": "Eisenbehälter",
+  "block.irontanks.silver_tank": "Silberbehälter",
+  "block.irontanks.gold_tank": "Goldbehälter",
+  "block.irontanks.diamond_tank": "Diamantbehälter",
+  "block.irontanks.obsidian_tank": "Obsidiantbehälter",
+  "item.irontanks.glass_copper_upgrade": "Glas zu Kupferbehälter Upgrade",
+  "item.irontanks.glass_iron_upgrade": "Glas zu Eisenbehälter Upgrade",
+  "item.irontanks.copper_iron_upgrade": "Kupfer zu Eisenbehälter Upgrade",
+  "item.irontanks.copper_silver_upgrade": "Kupfer zu Silberbehälter Upgrade",
+  "item.irontanks.iron_gold_upgrade": "Eisen zu Goldbehälter Upgrade",
+  "item.irontanks.silver_gold_upgrade": "Silber zu Goldbehälter Upgrade",
+  "item.irontanks.gold_diamond_upgrade": "Gold zu Diamantbehälter Upgrade",
+  "item.irontanks.diamond_obsidian_upgrade": "Diamant zu Obsidiantbehälter Upgrade",
+  "irontanks.tooltip.capacity": "hält %s eimer"
+}

--- a/resources/assets/irontanks/lang/en_pt.json
+++ b/resources/assets/irontanks/lang/en_pt.json
@@ -1,0 +1,19 @@
+{
+  "block.irontanks.copper_tank": "Copper Cask",
+  "block.irontanks.iron_tank": "Iron Cask",
+  "block.irontanks.silver_tank": "Silver Cask",
+  "block.irontanks.gold_tank": "Gold Cask",
+  "block.irontanks.diamond_tank": "Diamond Cask",
+  "block.irontanks.obsidian_tank": "Obsidian Cask",
+  "block.irontanks.emerald_tank": "Emerald Cask",
+  "item.irontanks.glass_copper_upgrade": "Glass t' Copper Cask Upgrade",
+  "item.irontanks.glass_iron_upgrade": "Glass t' Iron Cask Upgrade",
+  "item.irontanks.copper_iron_upgrade": "Copper t' Iron Cask Upgrade",
+  "item.irontanks.copper_silver_upgrade": "Copper t' Silver Cask Upgrade",
+  "item.irontanks.iron_gold_upgrade": "Iron t' Gold Cask Upgrade",
+  "item.irontanks.silver_gold_upgrade": "Silver t' Gold Cask Upgrade",
+  "item.irontanks.gold_diamond_upgrade": "Gold t' Diamond Cask Upgrade",
+  "item.irontanks.diamond_obsidian_upgrade": "Diamond t' Obsidian Cask Upgrade",
+  "item.irontanks.diamond_emerald_upgrade": "Diamond t' Emerald Cask Upgrade",
+  "irontanks.tooltip.capacity": "Holds %s buckets"
+}

--- a/resources/assets/irontanks/lang/es_es.json
+++ b/resources/assets/irontanks/lang/es_es.json
@@ -1,0 +1,17 @@
+{
+  "block.irontanks.copper_tank": "Tanque de Cobre",
+  "block.irontanks.iron_tank": "Tanque de Hierro",
+  "block.irontanks.silver_tank": "Tanque de Plata",
+  "block.irontanks.gold_tank": "Tanque de Oro",
+  "block.irontanks.diamond_tank": "Tanque de Diamante",
+  "block.irontanks.obsidian_tank": "Tanque de Obsidiana",
+  "item.irontanks.glass_copper_upgrade": "Mejora de Tanque de Vidrio a Cobre",
+  "item.irontanks.glass_iron_upgrade": "Mejora de Tanque de Vidrio a Hierro",
+  "item.irontanks.copper_iron_upgrade": "Mejora de Tanque de Cobre a Hierro",
+  "item.irontanks.copper_silver_upgrade": "Mejora de Tanque de Cobre a Plata",
+  "item.irontanks.iron_gold_upgrade": "Mejora de Tanque de Hierro a Oro",
+  "item.irontanks.silver_gold_upgrade": "Mejora de Tanque de Plata a Oro",
+  "item.irontanks.gold_diamond_upgrade": "Mejora de Tanque de Oro a Diamante",
+  "item.irontanks.diamond_obsidian_upgrade": "Mejora de Tanque de Diamante a Obsidiana",
+  "irontanks.tooltip.capacity": "tiene %s cubos"
+}

--- a/resources/assets/irontanks/lang/pt_br.json
+++ b/resources/assets/irontanks/lang/pt_br.json
@@ -1,0 +1,17 @@
+{
+  "block.irontanks.copper_tank": "Tanque de Cobre",
+  "block.irontanks.iron_tank": "Tanque de Ferro",
+  "block.irontanks.silver_tank": "Tanque de Prata",
+  "block.irontanks.gold_tank": "Tanque de Ouro",
+  "block.irontanks.diamond_tank": "Tanque de Diamante",
+  "block.irontanks.obsidian_tank": "Tanque de Obsidiana",
+  "item.irontanks.glass_copper_upgrade": "Aprimoramento de Tanque de Vidro para Cobre",
+  "item.irontanks.glass_iron_upgrade": "Aprimoramento de Tanque de Vidro para Ferro",
+  "item.irontanks.copper_iron_upgrade": "Aprimoramento de Tanque de Cobre para Ferro",
+  "item.irontanks.copper_silver_upgrade": "Aprimoramento de Tanque de Cobre para Prata",
+  "item.irontanks.iron_gold_upgrade": "Aprimoramento de Tanque de Ferro para Ouro",
+  "item.irontanks.silver_gold_upgrade": "Aprimoramento de Tanque de Prata para Ouro",
+  "item.irontanks.gold_diamond_upgrade": "Aprimoramento de Tanque de Ouro para Diamante",
+  "item.irontanks.diamond_obsidian_upgrade": "Aprimoramento de Tanque de Diamante para Obsidiana",
+  "irontanks.tooltip.capacity": "Contém %s baldes"
+}

--- a/resources/assets/irontanks/lang/ru_ru.json
+++ b/resources/assets/irontanks/lang/ru_ru.json
@@ -19,5 +19,5 @@
   "item.irontanks.diamond_emerald_upgrade": "Улучшение из алмазной в изумрудную цистерну",
   "irontanks.tooltip.capacity": "Удерживает %s ведер",
   "irontanks.tooltip.void_tank": "Уничтожает жидкости",
-  "irontanks.tooltip.creative_tank": "Хранит неограниченое кол-во жидкости"
+  "irontanks.tooltip.creative_tank": "Хранит неограниченное кол-во жидкости"
 }

--- a/resources/assets/irontanks/lang/ru_ru.json
+++ b/resources/assets/irontanks/lang/ru_ru.json
@@ -1,0 +1,23 @@
+{
+  "block.irontanks.copper_tank": "Медная цистерна",
+  "block.irontanks.iron_tank": "Железная цистерна",
+  "block.irontanks.silver_tank": "Серебряная цистерна",
+  "block.irontanks.gold_tank": "Золотая цистерна",
+  "block.irontanks.diamond_tank": "Алмазная цистерна",
+  "block.irontanks.obsidian_tank": "Обсидиановая цистерна",
+  "block.irontanks.emerald_tank": "Изумрудная цистерна",
+  "block.irontanks.void_tank": "Пустотная цистерна",
+  "block.irontanks.creative_tank": "Креативная цистерна",
+  "item.irontanks.glass_copper_upgrade": "Улучшение из стеклянной в медную цистерну",
+  "item.irontanks.glass_iron_upgrade": "Улучшение из стеклянной в железную цистерну",
+  "item.irontanks.copper_iron_upgrade": "Улучшение из медной в железную цистерну",
+  "item.irontanks.copper_silver_upgrade": "Улучшение из медной в серебряную цистерну",
+  "item.irontanks.iron_gold_upgrade": "Улучшение из железной в золотую цистерну",
+  "item.irontanks.silver_gold_upgrade": "Улучшение из серебряной в золотую цистерну",
+  "item.irontanks.gold_diamond_upgrade": "Улучшение из золотой в алмазную цистерну",
+  "item.irontanks.diamond_obsidian_upgrade": "Улучшение из алмазной в обсидиановую цистерну",
+  "item.irontanks.diamond_emerald_upgrade": "Улучшение из алмазной в изумрудную цистерну",
+  "irontanks.tooltip.capacity": "Удерживает %s ведер",
+  "irontanks.tooltip.void_tank": "Уничтожает жидкости",
+  "irontanks.tooltip.creative_tank": "Хранит неограниченое кол-во жидкости"
+}

--- a/resources/assets/irontanks/lang/zh_cn.json
+++ b/resources/assets/irontanks/lang/zh_cn.json
@@ -1,0 +1,21 @@
+{
+  "block.irontanks.copper_tank": "铜储罐",
+  "block.irontanks.iron_tank": "铁储罐",
+  "block.irontanks.silver_tank": "银储罐",
+  "block.irontanks.gold_tank": "金储罐",
+  "block.irontanks.diamond_tank": "钻石储罐",
+  "block.irontanks.obsidian_tank": "黑曜石储罐",
+  "block.irontanks.void_tank": "虚空储罐",
+  "block.irontanks.creative_tank": "创造储罐",
+  "item.irontanks.glass_copper_upgrade": "储罐升级：玻璃>铜",
+  "item.irontanks.glass_iron_upgrade": "储罐升级：玻璃>铁",
+  "item.irontanks.copper_iron_upgrade": "储罐升级：铜>铁",
+  "item.irontanks.copper_silver_upgrade": "储罐升级：铜>银",
+  "item.irontanks.iron_gold_upgrade": "储罐升级：铁>金",
+  "item.irontanks.silver_gold_upgrade": "储罐升级：银>金",
+  "item.irontanks.gold_diamond_upgrade": "储罐升级：金>钻石",
+  "item.irontanks.diamond_obsidian_upgrade": "储罐升级：钻石>黑曜石",
+  "irontanks.tooltip.capacity": "持有%s桶流体",
+  "irontanks.tooltip.void_tank": "销毁流体",
+  "irontanks.tooltip.creative_tank": "提供无限量的流体"
+}


### PR DESCRIPTION
## Summary

The Minecraft 26.1 rewrite shipped with only English. This restores the six community translations that the older Forge branches carried, ported into 26.1's modern flattened-JSON lang format.

## Changes

- **Added** translations for German (`de_de`), Spanish (`es_es`), Brazilian Portuguese (`pt_br`), Russian (`ru_ru`), Simplified Chinese (`zh_cn`), and Pirate Speak (`en_pt`).
- Remapped the legacy 1.12-era keys (`tile.*.name` / `item.*.name`) to the current `block.irontanks.*` / `item.irontanks.*` keys.
- Russian and Chinese are the most complete (incl. void & creative tank names and tooltips); the others cover tank names, upgrade items, and the capacity tooltip.

## Notes

- Strings that were never actually translated upstream (a few left as English) are omitted so Minecraft falls back to `en_us` per-key rather than carrying fake translations.
- Brand-new 26.1 strings (potion readout, glass tank, Jade HUD label) are intentionally English-only for now — they'll be picked up by the upcoming Crowdin workflow.