### PR TITLE
ci: add Crowdin localization sync

### DIFF
--- a/.github/workflows/sync_translations.yml
+++ b/.github/workflows/sync_translations.yml
@@ -1,0 +1,45 @@
+name: Sync Translations
+
+# Keeps Crowdin and the repo in sync: pushes new source strings up on every change to
+# mc/26.1, and pulls finished translations back down daily (and on demand) as a PR.
+on:
+  push:
+    branches: ['mc/26.1']
+    paths: ['resources/assets/irontanks/lang/en_us.json']
+  schedule:
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  crowdin:
+    name: crowdin
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Synchronize with Crowdin
+        uses: crowdin/github-action@v2
+        with:
+          upload_sources: true
+          upload_translations: false
+          download_translations: true
+          localization_branch_name: l10n/crowdin
+          create_pull_request: true
+          # Placeholder title — edit the PR title before squash-merging to name the
+          # specific languages (e.g. "feat: add German and Russian translations").
+          pull_request_title: 'fix: update translations'
+          pull_request_body: 'Automated translation update from [Crowdin](https://crowdin.com).'
+          pull_request_base_branch_name: 'mc/26.1'
+        env:
+          # PERSONAL_TOKEN (not GITHUB_TOKEN) so the opened PR triggers the check-code / check-pr gates.
+          GITHUB_TOKEN: ${{ secrets.PERSONAL_TOKEN }}
+          CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
+          CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -66,10 +66,18 @@ like. Full details in **[CRASH_REPORTING.md](CRASH_REPORTING.md)**.
 You don't need to write Java to help:
 
 1. **Spread the word** — every bit of support helps the mod keep improving.
-2. **Translate it** — add or improve a language.
+2. **[Translate it](#translating)** — add or improve a language on Crowdin.
 3. **[Report an issue](https://github.com/indemnity83/irontanks/issues)** if something's wrong or could be better.
 4. **[Open a pull request](https://github.com/indemnity83/irontanks/pulls)** — see `CLAUDE.md` for the
    build setup (a `core` + `fabric` + `neoforge` multiloader Gradle project on JDK 25).
+
+## Translating
+
+Iron Tanks is translated on [Crowdin](https://crowdin.com/project/iron-tanks). You don't need to touch
+the code — pick your language, translate the strings, and a bot opens a pull request with the results.
+New and updated translations sync automatically; English is the source language.
+
+Don't see your language? Open an issue and it'll be added to the project.
 
 ## License
 

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,0 +1,19 @@
+project_id_env: CROWDIN_PROJECT_ID
+api_token_env: CROWDIN_PERSONAL_TOKEN
+preserve_hierarchy: true
+
+files:
+  - source: /resources/assets/irontanks/lang/en_us.json
+    translation: /resources/assets/irontanks/lang/%locale%.json
+    # Crowdin emits region codes like pt-BR; Minecraft wants lowercase pt_br, so map
+    # each enabled Crowdin language to its Minecraft locale filename. Extend this as
+    # languages are enabled in the Crowdin project.
+    languages_mapping:
+      locale:
+        de: de_de
+        es-ES: es_es
+        pt-BR: pt_br
+        ru: ru_ru
+        zh-CN: zh_cn
+    # en_pt (Pirate Speak) is not a standard Crowdin language and is maintained by hand;
+    # it is intentionally left out of the mapping so the sync never overwrites it.


### PR DESCRIPTION
## Summary

Stands up a [Crowdin](https://crowdin.com) integration so translations are managed continuously instead of by hand. Iron Tanks qualifies for Crowdin's free **Open Source** license (MIT, OSI-approved), which grants unlimited projects/strings/members — so this doesn't compete with any other project's quota.

## Changes

- `crowdin.yml` — maps the `en_us.json` source to Minecraft-locale translation filenames (Crowdin's `pt-BR` → MC's `pt_br`, etc.).
- `.github/workflows/sync_translations.yml` — uploads source strings on changes to `mc/26.1`, pulls finished translations back daily / on demand, and opens a PR into `mc/26.1`.
- README — adds a **Translating** section pointing contributors to Crowdin.

## Notes

- Synced PRs open with the placeholder title `fix: update translations` (changelog-worthy under **Fixed**); edit the title before squash-merging to name the languages.
- Pirate Speak (`en_pt`) is hand-maintained and intentionally excluded from the Crowdin mapping.

## Setup checklist (manual — before the workflow can run)

- [x] Create the Crowdin project (source language English) and apply for the OSS license: https://crowdin.com/page/open-source-project-setup-request
- [x] Add repo secrets `CROWDIN_PROJECT_ID` and `CROWDIN_PERSONAL_TOKEN` (Crowdin → Account → API)
- [x] Confirm the Crowdin project slug in the README link (`crowdin.com/project/iron-tanks`)
- [x] Extend `languages_mapping` in `crowdin.yml` as more languages are enabled
- [x] Decide Pirate Speak handling (keep hand-maintained, or add as a Crowdin custom language)