### PR TITLE
ci: skip untranslated strings in Crowdin downloads

### DIFF
--- a/.github/workflows/sync_translations.yml
+++ b/.github/workflows/sync_translations.yml
@@ -31,6 +31,9 @@ jobs:
           upload_sources: true
           upload_translations: false
           download_translations: true
+          # Omit untranslated strings from the export so files don't carry English
+          # placeholders — Minecraft falls back to en_us per-key instead.
+          skip_untranslated_strings: true
           localization_branch_name: l10n/crowdin
           create_pull_request: true
           # Placeholder title — edit the PR title before squash-merging to name the


### PR DESCRIPTION
## Summary

The Crowdin download was filling untranslated entries with the English source text, so downloaded language files carried English placeholders. This sets `skip_untranslated_strings: true` so Crowdin omits untranslated strings from the export.

## Why it matters

Minecraft already falls back to `en_us` for any missing key, so omitting untranslated strings keeps each language file lean and avoids fake "translations" that are really just English — the same principle used for the originally restored files.

## Notes

- Affects the download/export only; source upload is unchanged.