### PR TITLE
feat: stack and share fluid with Logistics tanks

### DIFF
--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -41,6 +41,18 @@ dependencies {
     implementation "net.fabricmc.fabric-api:fabric-api:${rootProject.fabric_version}"
     implementation project(':core')
 
+    // Optional logistics integration: compile against the published logistics mod from the Modrinth maven
+    // (Mojang-mapped, no remapping needed — same pattern as Jade below). compileOnly + a runtime
+    // class-presence gate means the logistics API classes are only linked when logistics is installed, and
+    // nothing is bundled. Version pinned in gradle.properties.
+    compileOnly "maven.modrinth:logistics:${rootProject.logistics_version}.fabric"
+
+    // Dev-only: load the full logistics mod in runClient so cross-mod tank stacking and upgrades can be
+    // exercised. This 26.1 toolchain is Mojang-mapped end to end (same reason Jade below uses plain client*
+    // configs), so no Loom mod-remap config is needed: a plain runtimeOnly puts the jar on the run classpath
+    // where Fabric Loader discovers it and applies its access widener.
+    runtimeOnly "maven.modrinth:logistics:${rootProject.logistics_version}.fabric"
+
     // Optional Jade HUD integration: compile-only, on the client source set where the @WailaPlugin class
     // lives. The 26.1 Fabric toolchain is Mojang-mapped (as is Jade's jar), so no remapping is needed and
     // a plain clientCompileOnly suffices. The class only loads when Jade is actually installed.

--- a/fabric/src/main/java/com/indemnity83/irontanks/fabric/IronTanksFabric.java
+++ b/fabric/src/main/java/com/indemnity83/irontanks/fabric/IronTanksFabric.java
@@ -5,6 +5,7 @@ import com.indemnity83.irontanks.fabric.content.TankFluidStorage;
 import com.indemnity83.irontanks.fabric.crash.CrashReportingBootstrap;
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.transfer.v1.fluid.FluidStorage;
+import net.fabricmc.loader.api.FabricLoader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -26,6 +27,16 @@ public final class IronTanksFabric implements ModInitializer {
         // Expose every tank's fluid storage so pipes/pumps can fill and drain it.
         FluidStorage.SIDED.registerForBlockEntity(
                 (tank, direction) -> new TankFluidStorage(tank), IronTanksContent.TANK_BLOCK_ENTITY);
+
+        // Optional: when the logistics mod is present AND ships the tank-column API, wire iron tanks into
+        // its shared tank columns so the two mods' tanks stack and share fluid, and iron upgrades work on
+        // its glass tank. The bridge class is referenced only inside this guard, so its logistics imports
+        // never link when logistics is absent. The apiPresent() probe keeps an older logistics (same mod
+        // id, no API) from crashing init.
+        if (FabricLoader.getInstance().isModLoaded("logistics")
+                && com.indemnity83.irontanks.fabric.compat.LogisticsTanks.apiPresent()) {
+            com.indemnity83.irontanks.fabric.compat.logistics.LogisticsTanksBridge.init();
+        }
 
         // Opt-in (default off) sanitized crash reporting.
         CrashReportingBootstrap.init();

--- a/fabric/src/main/java/com/indemnity83/irontanks/fabric/IronTanksFabric.java
+++ b/fabric/src/main/java/com/indemnity83/irontanks/fabric/IronTanksFabric.java
@@ -35,7 +35,14 @@ public final class IronTanksFabric implements ModInitializer {
         // id, no API) from crashing init.
         if (FabricLoader.getInstance().isModLoaded("logistics")
                 && com.indemnity83.irontanks.fabric.compat.LogisticsTanks.apiPresent()) {
-            com.indemnity83.irontanks.fabric.compat.logistics.LogisticsTanksBridge.init();
+            try {
+                com.indemnity83.irontanks.fabric.compat.logistics.LogisticsTanksBridge.init();
+            } catch (Throwable t) {
+                // apiPresent() only confirms the probe class loads; a binary-incompatible logistics build
+                // could still fail to link a method here (LinkageError/NoClassDefFoundError). Degrade
+                // gracefully rather than crash mod init — iron tanks just run without the integration.
+                LOGGER.warn("Logistics tank integration failed to initialize; continuing without it", t);
+            }
         }
 
         // Opt-in (default off) sanitized crash reporting.

--- a/fabric/src/main/java/com/indemnity83/irontanks/fabric/compat/LogisticsTanks.java
+++ b/fabric/src/main/java/com/indemnity83/irontanks/fabric/compat/LogisticsTanks.java
@@ -1,0 +1,79 @@
+package com.indemnity83.irontanks.fabric.compat;
+
+import net.fabricmc.fabric.api.transfer.v1.fluid.FluidVariant;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.state.BlockState;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Neutral seam for the optional logistics integration. Holds no references to {@code com.logistics.*}
+ * types, so the content classes that call it (the tank block entity, the upgrade item) link cleanly
+ * whether or not logistics is installed.
+ *
+ * <p>When the logistics mod IS present, {@code com.indemnity83.irontanks.fabric.compat.logistics}
+ * installs a {@link Bridge} that drives a shared, cross-mod fluid column through the logistics API. That
+ * package — and only that package — references logistics types, and is class-loaded behind a
+ * mod-present check, so logistics' absence can never cause a {@code NoClassDefFoundError}.
+ */
+public final class LogisticsTanks {
+
+    /** A foreign (logistics) tank cell's contents, read for an in-place upgrade. Amount is in droplets. */
+    public record Contents(FluidVariant fluid, long droplets) {}
+
+    /** Implemented in the logistics-coupled compat package; installed only when logistics is present. */
+    public interface Bridge {
+        /** Whether {@code pos} is the single cell that should settle its (possibly cross-mod) column. */
+        boolean isColumnBottom(Level level, BlockPos pos);
+
+        /** Settle the whole column containing {@code pos}; changed cells (foreign included) sync themselves. */
+        void rebalanceColumn(Level level, BlockPos pos);
+
+        /** Whether {@code state} is a logistics tank that this mod's upgrade items can consume. */
+        boolean isForeignTank(BlockState state);
+
+        /** The logistics tank cell's contents at {@code pos} (droplets), or {@code null} if absent/empty. */
+        @Nullable
+        Contents readForeignTank(Level level, BlockPos pos);
+    }
+
+    @Nullable
+    private static volatile Bridge bridge;
+
+    private LogisticsTanks() {}
+
+    /** A tank-column API class whose presence signals a logistics build new enough to integrate with. */
+    private static final String API_PROBE_CLASS = "com.logistics.core.lib.tank.TankCellLookup";
+
+    /**
+     * Whether the installed logistics build actually ships the tank-column API this integration needs.
+     * The mod id alone is not enough — an older logistics could declare the same id without these classes —
+     * so the entry point must confirm the API is present before wiring the bridge, or {@code init()} would
+     * throw {@link NoClassDefFoundError}. Referenced only by name, so this class still links when logistics
+     * is absent.
+     */
+    public static boolean apiPresent() {
+        try {
+            Class.forName(API_PROBE_CLASS, false, LogisticsTanks.class.getClassLoader());
+            return true;
+        } catch (Throwable ignored) {
+            return false;
+        }
+    }
+
+    /** Install the logistics-backed bridge. Called once, only when the logistics mod is present. */
+    public static void install(Bridge installed) {
+        bridge = installed;
+    }
+
+    /** Whether the logistics integration is active (the mod is installed and wired). */
+    public static boolean active() {
+        return bridge != null;
+    }
+
+    /** The active bridge, or {@code null} when logistics is absent. Guard with {@link #active()}. */
+    @Nullable
+    public static Bridge get() {
+        return bridge;
+    }
+}

--- a/fabric/src/main/java/com/indemnity83/irontanks/fabric/compat/logistics/LogisticsTankCell.java
+++ b/fabric/src/main/java/com/indemnity83/irontanks/fabric/compat/logistics/LogisticsTankCell.java
@@ -1,0 +1,69 @@
+package com.indemnity83.irontanks.fabric.compat.logistics;
+
+import com.indemnity83.irontanks.core.TankTier;
+import com.indemnity83.irontanks.fabric.content.TankBlockEntity;
+import com.logistics.core.lib.fluids.IFluidKey;
+import com.logistics.core.lib.fluids.SimpleFluidKey;
+import com.logistics.core.lib.tank.TankCell;
+import net.fabricmc.fabric.api.transfer.v1.fluid.FluidVariant;
+
+/**
+ * Adapts an Iron Tanks {@link TankBlockEntity} to the logistics {@link TankCell} contract, so a logistics
+ * tank column can include iron tanks and settle the stack as one shared fluid body.
+ *
+ * <p>Iron Tanks cannot make {@code TankBlockEntity implements TankCell} directly: that interface is
+ * absent when logistics is not installed, so the block entity class would fail to load. This adapter
+ * (and everything in this package) is only ever class-loaded behind a mod-present check.
+ *
+ * <p>Fabric is droplet-native, which matches the logistics Fabric unit, so amounts pass through with no
+ * conversion. (The NeoForge adapter must convert droplets&harr;mB.)
+ */
+final class LogisticsTankCell implements TankCell {
+
+    private final TankBlockEntity tank;
+
+    LogisticsTankCell(TankBlockEntity tank) {
+        this.tank = tank;
+    }
+
+    static IFluidKey toKey(FluidVariant variant) {
+        return variant.isBlank()
+                ? SimpleFluidKey.BLANK
+                : new SimpleFluidKey(variant.getFluid(), variant.getComponentsPatch());
+    }
+
+    static FluidVariant toVariant(IFluidKey key) {
+        return key.isBlank() ? FluidVariant.blank() : FluidVariant.of(key.getFluid(), key.getComponents());
+    }
+
+    @Override
+    public IFluidKey fluid() {
+        return toKey(tank.fluidVariant());
+    }
+
+    @Override
+    public long amount() {
+        return tank.amount();
+    }
+
+    @Override
+    public long capacity() {
+        return tank.capacity();
+    }
+
+    @Override
+    public void setContents(IFluidKey fluid, long amount) {
+        // The logistics engine writes only the cells it actually changes during a rebalance, so syncing
+        // here (rather than batching) touches just those cells.
+        tank.setContentsRaw(toVariant(fluid), amount);
+        tank.sync();
+    }
+
+    @Override
+    public boolean joinsColumn() {
+        // Creative and void tanks stay isolated single-cell columns — creative would feed an endless
+        // source into a shared body, and void would silently destroy a neighbour's fluid.
+        TankTier tier = tank.tier();
+        return tier != TankTier.CREATIVE && tier != TankTier.VOID;
+    }
+}

--- a/fabric/src/main/java/com/indemnity83/irontanks/fabric/compat/logistics/LogisticsTanksBridge.java
+++ b/fabric/src/main/java/com/indemnity83/irontanks/fabric/compat/logistics/LogisticsTanksBridge.java
@@ -1,0 +1,62 @@
+package com.indemnity83.irontanks.fabric.compat.logistics;
+
+import com.indemnity83.irontanks.fabric.compat.LogisticsTanks;
+import com.indemnity83.irontanks.fabric.content.TankBlockEntity;
+import com.logistics.core.lib.tank.TankCell;
+import com.logistics.core.lib.tank.TankCellLookup;
+import com.logistics.core.lib.tank.TankColumns;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.resources.Identifier;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.state.BlockState;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Logistics-coupled implementation of {@link LogisticsTanks.Bridge}. Loaded only when the logistics mod
+ * is installed (see {@link #init()}), so its {@code com.logistics.*} references are never linked
+ * otherwise.
+ *
+ * <p>{@link #init()} registers Iron Tanks' block entities with the logistics {@link TankCellLookup} so a
+ * vertical column can span both mods, and installs this bridge so Iron Tanks routes its column rebalance
+ * through the shared logistics engine — driven by whichever mod owns the column's bottom block.
+ */
+public final class LogisticsTanksBridge implements LogisticsTanks.Bridge {
+
+    private static final Identifier GLASS_TANK_ID = Identifier.fromNamespaceAndPath("logistics", "glass_tank");
+
+    private LogisticsTanksBridge() {}
+
+    /** Wire Iron Tanks into the logistics tank-column system. Call only when logistics is present. */
+    public static void init() {
+        TankCellLookup.register((level, pos) ->
+                level.getBlockEntity(pos) instanceof TankBlockEntity tank ? new LogisticsTankCell(tank) : null);
+        LogisticsTanks.install(new LogisticsTanksBridge());
+    }
+
+    @Override
+    public boolean isColumnBottom(Level level, BlockPos pos) {
+        return TankColumns.isColumnBottom(level, pos);
+    }
+
+    @Override
+    public void rebalanceColumn(Level level, BlockPos pos) {
+        TankColumns.columnAt(level, pos).rebalance();
+    }
+
+    @Override
+    public boolean isForeignTank(BlockState state) {
+        // Identify logistics' Glass Tank by registry id — its block class is not on the API jar.
+        return GLASS_TANK_ID.equals(BuiltInRegistries.BLOCK.getKey(state.getBlock()));
+    }
+
+    @Override
+    @Nullable
+    public LogisticsTanks.Contents readForeignTank(Level level, BlockPos pos) {
+        TankCell cell = TankCellLookup.find(level, pos);
+        if (cell == null || cell.fluid().isBlank() || cell.amount() <= 0) {
+            return null;
+        }
+        return new LogisticsTanks.Contents(LogisticsTankCell.toVariant(cell.fluid()), cell.amount());
+    }
+}

--- a/fabric/src/main/java/com/indemnity83/irontanks/fabric/content/TankBlockEntity.java
+++ b/fabric/src/main/java/com/indemnity83/irontanks/fabric/content/TankBlockEntity.java
@@ -93,6 +93,11 @@ public class TankBlockEntity extends BlockEntity implements TankCell<FluidVarian
     /** Persist + sync after an external content change, then rebalance the column. */
     public void onContentsChanged() {
         sync();
+        // Rebalancing is server-only and needs a level. balanceColumn() guards this internally; guard the
+        // logistics branch the same way, since its engine would NPE on a null level or desync on the client.
+        if (level == null || level.isClientSide()) {
+            return;
+        }
         if (LogisticsTanks.active()) {
             // Settle the whole (possibly cross-mod) column through the shared logistics engine.
             LogisticsTanks.get().rebalanceColumn(level, worldPosition);

--- a/fabric/src/main/java/com/indemnity83/irontanks/fabric/content/TankBlockEntity.java
+++ b/fabric/src/main/java/com/indemnity83/irontanks/fabric/content/TankBlockEntity.java
@@ -4,6 +4,7 @@ import com.indemnity83.irontanks.core.TankCell;
 import com.indemnity83.irontanks.core.TankColumn;
 import com.indemnity83.irontanks.core.TankTier;
 import com.indemnity83.irontanks.core.VoidTank;
+import com.indemnity83.irontanks.fabric.compat.LogisticsTanks;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Deque;
@@ -92,7 +93,12 @@ public class TankBlockEntity extends BlockEntity implements TankCell<FluidVarian
     /** Persist + sync after an external content change, then rebalance the column. */
     public void onContentsChanged() {
         sync();
-        balanceColumn();
+        if (LogisticsTanks.active()) {
+            // Settle the whole (possibly cross-mod) column through the shared logistics engine.
+            LogisticsTanks.get().rebalanceColumn(level, worldPosition);
+        } else {
+            balanceColumn();
+        }
     }
 
     /** This tank's vertical column, ordered bottom-to-top (creative tanks stay isolated). */
@@ -128,7 +134,14 @@ public class TankBlockEntity extends BlockEntity implements TankCell<FluidVarian
             setContentsRaw(fluid, capacity());
             changed = true;
         }
-        if (balanceColumn()) {
+        if (LogisticsTanks.active()) {
+            // Logistics elects one driver per (possibly cross-mod) column — its bottom cell — and settles
+            // the whole stack; changed cells (foreign included) sync themselves. Every other cell no-ops,
+            // so the two mods' tickers never fight over a shared column.
+            if (LogisticsTanks.get().isColumnBottom(level, worldPosition)) {
+                LogisticsTanks.get().rebalanceColumn(level, worldPosition);
+            }
+        } else if (balanceColumn()) {
             changed = true;
         }
         if (changed) {

--- a/fabric/src/main/java/com/indemnity83/irontanks/fabric/content/UpgradeItem.java
+++ b/fabric/src/main/java/com/indemnity83/irontanks/fabric/content/UpgradeItem.java
@@ -2,6 +2,7 @@ package com.indemnity83.irontanks.fabric.content;
 
 import com.indemnity83.irontanks.core.TankTier;
 import com.indemnity83.irontanks.core.TankUpgrade;
+import com.indemnity83.irontanks.fabric.compat.LogisticsTanks;
 import net.fabricmc.fabric.api.transfer.v1.fluid.FluidVariant;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.InteractionResult;
@@ -30,7 +31,13 @@ public class UpgradeItem extends Item {
         Level level = context.getLevel();
         BlockPos pos = context.getClickedPos();
         BlockState state = level.getBlockState(pos);
-        if (!(state.getBlock() instanceof TankBlock tank) || tank.tier() != upgrade.from()) {
+        boolean ownSource = state.getBlock() instanceof TankBlock tank && tank.tier() == upgrade.from();
+        // A glass-tier upgrade also accepts the logistics glass tank as its source when that mod is present.
+        boolean foreignSource = !ownSource
+                && upgrade.from() == TankTier.GLASS
+                && LogisticsTanks.active()
+                && LogisticsTanks.get().isForeignTank(state);
+        if (!ownSource && !foreignSource) {
             return InteractionResult.PASS;
         }
 
@@ -39,7 +46,13 @@ public class UpgradeItem extends Item {
 
             FluidVariant fluid = FluidVariant.blank();
             long amount = 0;
-            if (level.getBlockEntity(pos) instanceof TankBlockEntity old) {
+            if (foreignSource) {
+                LogisticsTanks.Contents contents = LogisticsTanks.get().readForeignTank(level, pos);
+                if (contents != null) {
+                    fluid = contents.fluid();
+                    amount = contents.droplets();
+                }
+            } else if (level.getBlockEntity(pos) instanceof TankBlockEntity old) {
                 fluid = old.fluidVariant();
                 amount = old.amount();
             }

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -30,5 +30,8 @@
     "fabric-api": ">=${fabric_version}",
     "java": ">=${java_version}",
     "minecraft": "${fabric_minecraft_version_range}"
+  },
+  "suggests": {
+    "logistics": "*"
   }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -49,6 +49,11 @@ jacoco_version=0.8.14
 jade_neoforge_version=26.1.1+neoforge
 jade_fabric_version=26.1.0+fabric
 
+# Logistics — optional integration. Compile-only against the published logistics mod from the Modrinth
+# maven (the same artifact players install supplies these API classes at runtime). The loader suffix
+# (.neoforge / .fabric) is appended in each build.gradle. Bump when targeting a newer logistics release.
+logistics_version=0.7.3+mc26.1
+
 # Code formatting (Spotless: palantir-java-format for Java, gson for JSON)
 spotless_version=8.6.0
 palantir_version=2.91.0

--- a/neoforge/build.gradle
+++ b/neoforge/build.gradle
@@ -28,6 +28,16 @@ repositories {
 dependencies {
     implementation project(':core')
 
+    // Optional logistics integration: compile against the published logistics mod from the Modrinth maven
+    // (Mojang-mapped, same as the NeoForge runtime — same pattern as Jade below). compileOnly + a runtime
+    // class-presence gate means the logistics API classes are only linked when logistics is installed, and
+    // nothing is bundled. Version pinned in gradle.properties.
+    compileOnly "maven.modrinth:logistics:${rootProject.logistics_version}.neoforge"
+    // Dev-only: load the full logistics mod in runClient so cross-mod tank stacking and upgrades can be
+    // exercised. runtimeOnly (ModDevGradle's way to add dev mods) puts it on the run classpath but never in
+    // the shipped jar.
+    runtimeOnly "maven.modrinth:logistics:${rootProject.logistics_version}.neoforge"
+
     // Optional Jade HUD integration: compile-only so we implement its plugin API without making Jade a
     // hard dependency. The @WailaPlugin class only loads when Jade (a client mod) is actually present.
     compileOnly "maven.modrinth:jade:${rootProject.jade_neoforge_version}"

--- a/neoforge/src/main/java/com/indemnity83/irontanks/neoforge/IronTanksNeoForge.java
+++ b/neoforge/src/main/java/com/indemnity83/irontanks/neoforge/IronTanksNeoForge.java
@@ -4,7 +4,9 @@ import com.indemnity83.irontanks.neoforge.client.IronTanksClient;
 import com.indemnity83.irontanks.neoforge.content.IronTanksContent;
 import com.indemnity83.irontanks.neoforge.crash.CrashReportingBootstrap;
 import net.neoforged.bus.api.IEventBus;
+import net.neoforged.fml.ModList;
 import net.neoforged.fml.common.Mod;
+import net.neoforged.fml.event.lifecycle.FMLCommonSetupEvent;
 import net.neoforged.fml.loading.FMLEnvironment;
 import net.neoforged.neoforge.registries.RegisterEvent;
 import org.slf4j.Logger;
@@ -29,6 +31,19 @@ public final class IronTanksNeoForge {
         if (FMLEnvironment.getDist().isClient()) {
             IronTanksClient.register(modBus);
         }
+
+        // Optional: when the logistics mod is present AND ships the tank-column API, wire iron tanks into
+        // its shared tank columns so the two mods' tanks stack and share fluid, and iron upgrades work on
+        // its glass tank. Done at common setup (ModList is populated by then); the bridge class is referenced
+        // only inside the guard, so its logistics imports never link when logistics is absent. The
+        // apiPresent() probe keeps an older logistics (same mod id, no API) from crashing init. Iron Tanks
+        // works fully standalone.
+        modBus.addListener((FMLCommonSetupEvent event) -> {
+            if (ModList.get().isLoaded("logistics")
+                    && com.indemnity83.irontanks.neoforge.compat.LogisticsTanks.apiPresent()) {
+                com.indemnity83.irontanks.neoforge.compat.logistics.LogisticsTanksBridge.init();
+            }
+        });
 
         // Opt-in (default off) sanitized crash reporting.
         CrashReportingBootstrap.init();

--- a/neoforge/src/main/java/com/indemnity83/irontanks/neoforge/IronTanksNeoForge.java
+++ b/neoforge/src/main/java/com/indemnity83/irontanks/neoforge/IronTanksNeoForge.java
@@ -41,7 +41,14 @@ public final class IronTanksNeoForge {
         modBus.addListener((FMLCommonSetupEvent event) -> {
             if (ModList.get().isLoaded("logistics")
                     && com.indemnity83.irontanks.neoforge.compat.LogisticsTanks.apiPresent()) {
-                com.indemnity83.irontanks.neoforge.compat.logistics.LogisticsTanksBridge.init();
+                try {
+                    com.indemnity83.irontanks.neoforge.compat.logistics.LogisticsTanksBridge.init();
+                } catch (Throwable t) {
+                    // apiPresent() only confirms the probe class loads; a binary-incompatible logistics
+                    // build could still fail to link a method here (LinkageError/NoClassDefFoundError).
+                    // Degrade gracefully rather than crash mod init — iron tanks run without the integration.
+                    LOGGER.warn("Logistics tank integration failed to initialize; continuing without it", t);
+                }
             }
         });
 

--- a/neoforge/src/main/java/com/indemnity83/irontanks/neoforge/compat/LogisticsTanks.java
+++ b/neoforge/src/main/java/com/indemnity83/irontanks/neoforge/compat/LogisticsTanks.java
@@ -1,0 +1,79 @@
+package com.indemnity83.irontanks.neoforge.compat;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.state.BlockState;
+import net.neoforged.neoforge.transfer.fluid.FluidResource;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Neutral seam for the optional logistics integration. Holds no references to {@code com.logistics.*}
+ * types, so the content classes that call it (the tank block entity, the upgrade item) link cleanly
+ * whether or not logistics is installed.
+ *
+ * <p>When the logistics mod IS present, {@code com.indemnity83.irontanks.neoforge.compat.logistics}
+ * installs a {@link Bridge} that drives a shared, cross-mod fluid column through the logistics API. That
+ * package — and only that package — references logistics types, and is class-loaded behind a
+ * mod-present check, so logistics' absence can never cause a {@code NoClassDefFoundError}.
+ */
+public final class LogisticsTanks {
+
+    /** A foreign (logistics) tank cell's contents, read for an in-place upgrade. Amount is in droplets. */
+    public record Contents(FluidResource fluid, long droplets) {}
+
+    /** Implemented in the logistics-coupled compat package; installed only when logistics is present. */
+    public interface Bridge {
+        /** Whether {@code pos} is the single cell that should settle its (possibly cross-mod) column. */
+        boolean isColumnBottom(Level level, BlockPos pos);
+
+        /** Settle the whole column containing {@code pos}; changed cells (foreign included) sync themselves. */
+        void rebalanceColumn(Level level, BlockPos pos);
+
+        /** Whether {@code state} is a logistics tank that this mod's upgrade items can consume. */
+        boolean isForeignTank(BlockState state);
+
+        /** The logistics tank cell's contents at {@code pos} (droplets), or {@code null} if absent/empty. */
+        @Nullable
+        Contents readForeignTank(Level level, BlockPos pos);
+    }
+
+    @Nullable
+    private static volatile Bridge bridge;
+
+    private LogisticsTanks() {}
+
+    /** A tank-column API class whose presence signals a logistics build new enough to integrate with. */
+    private static final String API_PROBE_CLASS = "com.logistics.core.lib.tank.TankCellLookup";
+
+    /**
+     * Whether the installed logistics build actually ships the tank-column API this integration needs.
+     * The mod id alone is not enough — an older logistics could declare the same id without these classes —
+     * so the entry point must confirm the API is present before wiring the bridge, or {@code init()} would
+     * throw {@link NoClassDefFoundError}. Referenced only by name, so this class still links when logistics
+     * is absent.
+     */
+    public static boolean apiPresent() {
+        try {
+            Class.forName(API_PROBE_CLASS, false, LogisticsTanks.class.getClassLoader());
+            return true;
+        } catch (Throwable ignored) {
+            return false;
+        }
+    }
+
+    /** Install the logistics-backed bridge. Called once, only when the logistics mod is present. */
+    public static void install(Bridge installed) {
+        bridge = installed;
+    }
+
+    /** Whether the logistics integration is active (the mod is installed and wired). */
+    public static boolean active() {
+        return bridge != null;
+    }
+
+    /** The active bridge, or {@code null} when logistics is absent. Guard with {@link #active()}. */
+    @Nullable
+    public static Bridge get() {
+        return bridge;
+    }
+}

--- a/neoforge/src/main/java/com/indemnity83/irontanks/neoforge/compat/logistics/LogisticsTankCell.java
+++ b/neoforge/src/main/java/com/indemnity83/irontanks/neoforge/compat/logistics/LogisticsTankCell.java
@@ -1,0 +1,77 @@
+package com.indemnity83.irontanks.neoforge.compat.logistics;
+
+import com.indemnity83.irontanks.core.TankTier;
+import com.indemnity83.irontanks.neoforge.content.TankBlockEntity;
+import com.logistics.core.lib.fluids.IFluidKey;
+import com.logistics.core.lib.fluids.SimpleFluidKey;
+import com.logistics.core.lib.tank.TankCell;
+import net.neoforged.neoforge.transfer.fluid.FluidResource;
+
+/**
+ * Adapts an Iron Tanks {@link TankBlockEntity} to the logistics {@link TankCell} contract, so a logistics
+ * tank column can include iron tanks and settle the stack as one shared fluid body.
+ *
+ * <p>Iron Tanks cannot make {@code TankBlockEntity implements TankCell} directly: that interface is
+ * absent when logistics is not installed, so the block entity class would fail to load. This adapter
+ * (and everything in this package) is only ever class-loaded behind a mod-present check.
+ *
+ * <p><b>Units.</b> Iron Tanks stores droplets; logistics is millibucket-native on NeoForge. This adapter
+ * converts at the boundary ({@link TankTier#DROPLETS_PER_MB}). Capacities are whole millibuckets, but a
+ * cell amount that carries a sub-millibucket droplet remainder (only bottle/potion deposits do) loses
+ * that remainder when settled through the shared engine — a known NeoForge-only limitation for
+ * cross-mod columns; whole-millibucket fluids (water, lava, …) are exact.
+ */
+final class LogisticsTankCell implements TankCell {
+
+    private final TankBlockEntity tank;
+
+    LogisticsTankCell(TankBlockEntity tank) {
+        this.tank = tank;
+    }
+
+    static IFluidKey toKey(FluidResource resource) {
+        return resource.isEmpty()
+                ? SimpleFluidKey.BLANK
+                : new SimpleFluidKey(resource.getFluid(), resource.getComponentsPatch());
+    }
+
+    static FluidResource toResource(IFluidKey key) {
+        return key.isBlank() ? FluidResource.EMPTY : FluidResource.of(key.getFluid(), key.getComponents());
+    }
+
+    /** Droplets &rarr; millibuckets (logistics' NeoForge native unit). */
+    static long toMillibuckets(long droplets) {
+        return droplets / TankTier.DROPLETS_PER_MB;
+    }
+
+    @Override
+    public IFluidKey fluid() {
+        return toKey(tank.fluidResource());
+    }
+
+    @Override
+    public long amount() {
+        return toMillibuckets(tank.amount());
+    }
+
+    @Override
+    public long capacity() {
+        return toMillibuckets(tank.capacity());
+    }
+
+    @Override
+    public void setContents(IFluidKey fluid, long millibuckets) {
+        // The logistics engine writes only the cells it actually changes during a rebalance, so syncing
+        // here (rather than batching) touches just those cells.
+        tank.setContentsRaw(toResource(fluid), millibuckets * TankTier.DROPLETS_PER_MB);
+        tank.sync();
+    }
+
+    @Override
+    public boolean joinsColumn() {
+        // Creative and void tanks stay isolated single-cell columns — creative would feed an endless
+        // source into a shared body, and void would silently destroy a neighbour's fluid.
+        TankTier tier = tank.tier();
+        return tier != TankTier.CREATIVE && tier != TankTier.VOID;
+    }
+}

--- a/neoforge/src/main/java/com/indemnity83/irontanks/neoforge/compat/logistics/LogisticsTanksBridge.java
+++ b/neoforge/src/main/java/com/indemnity83/irontanks/neoforge/compat/logistics/LogisticsTanksBridge.java
@@ -1,0 +1,65 @@
+package com.indemnity83.irontanks.neoforge.compat.logistics;
+
+import com.indemnity83.irontanks.core.TankTier;
+import com.indemnity83.irontanks.neoforge.compat.LogisticsTanks;
+import com.indemnity83.irontanks.neoforge.content.TankBlockEntity;
+import com.logistics.core.lib.tank.TankCell;
+import com.logistics.core.lib.tank.TankCellLookup;
+import com.logistics.core.lib.tank.TankColumns;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.resources.Identifier;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.state.BlockState;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Logistics-coupled implementation of {@link LogisticsTanks.Bridge}. Loaded only when the logistics mod
+ * is installed (see {@link #init()}), so its {@code com.logistics.*} references are never linked
+ * otherwise.
+ *
+ * <p>{@link #init()} registers Iron Tanks' block entities with the logistics {@link TankCellLookup} so a
+ * vertical column can span both mods, and installs this bridge so Iron Tanks routes its column rebalance
+ * through the shared logistics engine — driven by whichever mod owns the column's bottom block.
+ */
+public final class LogisticsTanksBridge implements LogisticsTanks.Bridge {
+
+    private static final Identifier GLASS_TANK_ID = Identifier.fromNamespaceAndPath("logistics", "glass_tank");
+
+    private LogisticsTanksBridge() {}
+
+    /** Wire Iron Tanks into the logistics tank-column system. Call only when logistics is present. */
+    public static void init() {
+        TankCellLookup.register((level, pos) ->
+                level.getBlockEntity(pos) instanceof TankBlockEntity tank ? new LogisticsTankCell(tank) : null);
+        LogisticsTanks.install(new LogisticsTanksBridge());
+    }
+
+    @Override
+    public boolean isColumnBottom(Level level, BlockPos pos) {
+        return TankColumns.isColumnBottom(level, pos);
+    }
+
+    @Override
+    public void rebalanceColumn(Level level, BlockPos pos) {
+        TankColumns.columnAt(level, pos).rebalance();
+    }
+
+    @Override
+    public boolean isForeignTank(BlockState state) {
+        // Identify logistics' Glass Tank by registry id — its block class is not on the API jar.
+        return GLASS_TANK_ID.equals(BuiltInRegistries.BLOCK.getKey(state.getBlock()));
+    }
+
+    @Override
+    @Nullable
+    public LogisticsTanks.Contents readForeignTank(Level level, BlockPos pos) {
+        TankCell cell = TankCellLookup.find(level, pos);
+        if (cell == null || cell.fluid().isBlank() || cell.amount() <= 0) {
+            return null;
+        }
+        // cell.amount() is in logistics' millibuckets; Iron Tanks tracks droplets.
+        long droplets = cell.amount() * TankTier.DROPLETS_PER_MB;
+        return new LogisticsTanks.Contents(LogisticsTankCell.toResource(cell.fluid()), droplets);
+    }
+}

--- a/neoforge/src/main/java/com/indemnity83/irontanks/neoforge/content/TankBlockEntity.java
+++ b/neoforge/src/main/java/com/indemnity83/irontanks/neoforge/content/TankBlockEntity.java
@@ -4,6 +4,7 @@ import com.indemnity83.irontanks.core.TankCell;
 import com.indemnity83.irontanks.core.TankColumn;
 import com.indemnity83.irontanks.core.TankTier;
 import com.indemnity83.irontanks.core.VoidTank;
+import com.indemnity83.irontanks.neoforge.compat.LogisticsTanks;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Deque;
@@ -88,7 +89,12 @@ public class TankBlockEntity extends BlockEntity implements TankCell<FluidResour
     /** Persist + sync after an external content change, then rebalance the column. */
     public void onContentsChanged() {
         sync();
-        balanceColumn();
+        if (LogisticsTanks.active()) {
+            // Settle the whole (possibly cross-mod) column through the shared logistics engine.
+            LogisticsTanks.get().rebalanceColumn(level, worldPosition);
+        } else {
+            balanceColumn();
+        }
     }
 
     /** This tank's vertical column, ordered bottom-to-top (creative tanks stay isolated). */
@@ -125,7 +131,14 @@ public class TankBlockEntity extends BlockEntity implements TankCell<FluidResour
             setContentsRaw(fluid, capacity());
             changed = true;
         }
-        if (balanceColumn()) {
+        if (LogisticsTanks.active()) {
+            // Logistics elects one driver per (possibly cross-mod) column — its bottom cell — and settles
+            // the whole stack; changed cells (foreign included) sync themselves. Every other cell no-ops,
+            // so the two mods' tickers never fight over a shared column.
+            if (LogisticsTanks.get().isColumnBottom(level, worldPosition)) {
+                LogisticsTanks.get().rebalanceColumn(level, worldPosition);
+            }
+        } else if (balanceColumn()) {
             changed = true;
         }
         if (changed) {

--- a/neoforge/src/main/java/com/indemnity83/irontanks/neoforge/content/TankBlockEntity.java
+++ b/neoforge/src/main/java/com/indemnity83/irontanks/neoforge/content/TankBlockEntity.java
@@ -89,6 +89,11 @@ public class TankBlockEntity extends BlockEntity implements TankCell<FluidResour
     /** Persist + sync after an external content change, then rebalance the column. */
     public void onContentsChanged() {
         sync();
+        // Rebalancing is server-only and needs a level. balanceColumn() guards this internally; guard the
+        // logistics branch the same way, since its engine would NPE on a null level or desync on the client.
+        if (level == null || level.isClientSide()) {
+            return;
+        }
         if (LogisticsTanks.active()) {
             // Settle the whole (possibly cross-mod) column through the shared logistics engine.
             LogisticsTanks.get().rebalanceColumn(level, worldPosition);

--- a/neoforge/src/main/java/com/indemnity83/irontanks/neoforge/content/UpgradeItem.java
+++ b/neoforge/src/main/java/com/indemnity83/irontanks/neoforge/content/UpgradeItem.java
@@ -2,6 +2,7 @@ package com.indemnity83.irontanks.neoforge.content;
 
 import com.indemnity83.irontanks.core.TankTier;
 import com.indemnity83.irontanks.core.TankUpgrade;
+import com.indemnity83.irontanks.neoforge.compat.LogisticsTanks;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.item.Item;
@@ -30,7 +31,13 @@ public class UpgradeItem extends Item {
         Level level = context.getLevel();
         BlockPos pos = context.getClickedPos();
         BlockState state = level.getBlockState(pos);
-        if (!(state.getBlock() instanceof TankBlock tank) || tank.tier() != upgrade.from()) {
+        boolean ownSource = state.getBlock() instanceof TankBlock tank && tank.tier() == upgrade.from();
+        // A glass-tier upgrade also accepts the logistics glass tank as its source when that mod is present.
+        boolean foreignSource = !ownSource
+                && upgrade.from() == TankTier.GLASS
+                && LogisticsTanks.active()
+                && LogisticsTanks.get().isForeignTank(state);
+        if (!ownSource && !foreignSource) {
             return InteractionResult.PASS;
         }
 
@@ -39,7 +46,13 @@ public class UpgradeItem extends Item {
 
             FluidResource fluid = FluidResource.EMPTY;
             long amount = 0;
-            if (level.getBlockEntity(pos) instanceof TankBlockEntity old) {
+            if (foreignSource) {
+                LogisticsTanks.Contents contents = LogisticsTanks.get().readForeignTank(level, pos);
+                if (contents != null) {
+                    fluid = contents.fluid();
+                    amount = contents.droplets();
+                }
+            } else if (level.getBlockEntity(pos) instanceof TankBlockEntity old) {
                 fluid = old.fluidResource();
                 amount = old.amount();
             }

--- a/neoforge/src/main/resources/META-INF/neoforge.mods.toml
+++ b/neoforge/src/main/resources/META-INF/neoforge.mods.toml
@@ -25,3 +25,12 @@ type="required"
 versionRange="${neoforge_minecraft_version_range}"
 ordering="NONE"
 side="BOTH"
+
+# Optional cross-mod tank integration: iron tanks stack and share fluid with logistics tanks, and
+# iron upgrade items work on the logistics glass tank. Iron Tanks works fully without logistics.
+[[dependencies.${mod_id}]]
+modId="logistics"
+type="optional"
+versionRange="[0,)"
+ordering="AFTER"
+side="BOTH"


### PR DESCRIPTION
## Summary

When the [Logistics](https://modrinth.com/mod/logistics) mod is installed, Iron Tanks now interoperates with its tanks. Vertical stacks can mix tanks from both mods into one shared fluid column, and Iron Tank upgrade items work on the Logistics glass tank. Iron Tanks remains fully standalone — nothing changes if Logistics isn't present.

## Changes

- **Shared columns** — a vertical stack of Iron Tanks and Logistics tanks settles as one continuous fluid body. The column is driven by whichever mod owns the bottom block, so the two mods' tickers never fight over a shared stack.
- **Cross-mod upgrades** — a glass-tier Iron Tank upgrade item also promotes a Logistics glass tank, preserving its contents.
- **Creative/void stay isolated** — creative and void tanks remain single-cell columns so they can't feed or silently destroy a neighbour's fluid.

## Notes

- The integration is **optional** and self-contained. All `com.logistics.*` references live behind a mod-present + API-present guard, so Logistics' absence can never cause a `NoClassDefFoundError`.
- Iron Tanks compiles against the published Logistics mod from the Modrinth maven (pinned via `logistics_version` in `gradle.properties`) — no extra build setup or local checkout required.
- An `apiPresent()` class probe means pairing this build with a Logistics version that predates the tank-column API simply skips the integration rather than crashing.