### PR TITLE
feat: show fluid capacity in tank tooltips

### DIFF
--- a/src/main/java/com/indemnity83/irontank/init/ModBlocks.java
+++ b/src/main/java/com/indemnity83/irontank/init/ModBlocks.java
@@ -1,6 +1,7 @@
 package com.indemnity83.irontank.init;
 
 import com.indemnity83.irontank.block.BlockExtendedTank;
+import com.indemnity83.irontank.item.ItemBlockExtendedTank;
 import com.indemnity83.irontank.reference.TankType;
 
 import cpw.mods.fml.common.registry.GameRegistry;
@@ -20,17 +21,17 @@ public class ModBlocks {
 	public static final BlockExtendedTank tungstenSteelTank = new BlockExtendedTank(TankType.TUNGSTENSTEEL);
 
 	public static void init() {
-		GameRegistry.registerBlock(ironTank, ironTank.type.name);
-		GameRegistry.registerBlock(goldTank, goldTank.type.name);
-		GameRegistry.registerBlock(diamondTank, diamondTank.type.name);
-		GameRegistry.registerBlock(obsidianTank, obsidianTank.type.name);
-		GameRegistry.registerBlock(emeraldTank, emeraldTank.type.name);
-		GameRegistry.registerBlock(copperTank, copperTank.type.name);
-		GameRegistry.registerBlock(silverTank, silverTank.type.name);
-		GameRegistry.registerBlock(aluminiumTank, aluminiumTank.type.name);
-		GameRegistry.registerBlock(stainlessSteelTank, stainlessSteelTank.type.name);
-		GameRegistry.registerBlock(titaniumTank, titaniumTank.type.name);
-		GameRegistry.registerBlock(tungstenSteelTank, tungstenSteelTank.type.name);
+		GameRegistry.registerBlock(ironTank, ItemBlockExtendedTank.class, ironTank.type.name);
+		GameRegistry.registerBlock(goldTank, ItemBlockExtendedTank.class, goldTank.type.name);
+		GameRegistry.registerBlock(diamondTank, ItemBlockExtendedTank.class, diamondTank.type.name);
+		GameRegistry.registerBlock(obsidianTank, ItemBlockExtendedTank.class, obsidianTank.type.name);
+		GameRegistry.registerBlock(emeraldTank, ItemBlockExtendedTank.class, emeraldTank.type.name);
+		GameRegistry.registerBlock(copperTank, ItemBlockExtendedTank.class, copperTank.type.name);
+		GameRegistry.registerBlock(silverTank, ItemBlockExtendedTank.class, silverTank.type.name);
+		GameRegistry.registerBlock(aluminiumTank, ItemBlockExtendedTank.class, aluminiumTank.type.name);
+		GameRegistry.registerBlock(stainlessSteelTank, ItemBlockExtendedTank.class, stainlessSteelTank.type.name);
+		GameRegistry.registerBlock(titaniumTank, ItemBlockExtendedTank.class, titaniumTank.type.name);
+		GameRegistry.registerBlock(tungstenSteelTank, ItemBlockExtendedTank.class, tungstenSteelTank.type.name);
 	}
 
 }

--- a/src/main/java/com/indemnity83/irontank/item/ItemBlockExtendedTank.java
+++ b/src/main/java/com/indemnity83/irontank/item/ItemBlockExtendedTank.java
@@ -1,0 +1,31 @@
+package com.indemnity83.irontank.item;
+
+import java.util.List;
+
+import net.minecraft.block.Block;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemBlock;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.StatCollector;
+
+import com.indemnity83.irontank.block.BlockExtendedTank;
+
+/**
+ * ItemBlock for the tanks that shows the tank's fluid capacity in its tooltip.
+ */
+public class ItemBlockExtendedTank extends ItemBlock {
+
+	public ItemBlockExtendedTank(Block block) {
+		super(block);
+	}
+
+	@SuppressWarnings({"unchecked", "rawtypes"})
+	@Override
+	public void addInformation(ItemStack stack, EntityPlayer player, List list, boolean advanced) {
+		if (this.field_150939_a instanceof BlockExtendedTank) {
+			BlockExtendedTank tank = (BlockExtendedTank) this.field_150939_a;
+			list.add(StatCollector.translateToLocalFormatted("irontank.tooltip.capacity", tank.type.capacity));
+		}
+	}
+
+}

--- a/src/main/resources/assets/irontank/lang/en_US.lang
+++ b/src/main/resources/assets/irontank/lang/en_US.lang
@@ -30,3 +30,4 @@ tile.irontank:tungstensteeltank.name=Tungsten Steel Tank
 
 # Misc localizations
 itemGroup.irontank=Iron Tanks
+irontank.tooltip.capacity=Holds %s buckets


### PR DESCRIPTION
## Summary

Held or hovered tanks now show their fluid capacity in the tooltip — e.g.
"Holds 32 buckets" — so players can tell tiers apart without checking the wiki.

Implements #150. This was the only line missing capacity tooltips; 1.11.2,
1.12.2, and 26.1 already have them.

## Changes

- New `ItemBlockExtendedTank` whose `addInformation` adds a localized
  "Holds N buckets" line from the tank's tier capacity.
- All tank blocks (every tier, including the new aluminium/stainless/titanium/
  tungsten tiers) register with it.
- `irontank.tooltip.capacity` lang key added.

## Notes

- Compiles clean (`./gradlew compileJava`); in-game test pending.
- English only for now; other locales fall back to `en_US`.
