### PR TITLE
feat: per-tier tank hardness and blast resistance

### DIFF
--- a/core/src/main/java/com/indemnity83/irontanks/core/TankTier.java
+++ b/core/src/main/java/com/indemnity83/irontanks/core/TankTier.java
@@ -12,24 +12,25 @@ package com.indemnity83.irontanks.core;
  * everywhere else in {@code core} are tracked in droplets (see {@link #capacity()}).
  */
 public enum TankTier {
-    GLASS(16),
-    COPPER(27),
-    IRON(32),
-    SILVER(43),
-    GOLD(48),
-    DIAMOND(64),
+    // buckets, hardness (mining time), blastResistance (explosion resistance)
+    GLASS(16, 0.3F, 0.3F),
+    COPPER(27, 4.0F, 2.0F),
+    IRON(32, 5.0F, 3.0F),
+    SILVER(43, 6.0F, 5.0F),
+    GOLD(48, 7.0F, 4.0F),
+    DIAMOND(64, 8.0F, 6.0F),
     /** Explosion-proof; same capacity as diamond. */
-    OBSIDIAN(64),
-    EMERALD(96),
+    OBSIDIAN(64, 50.0F, 1200.0F),
+    EMERALD(96, 8.0F, 6.0F),
     /** Optional high tiers, gated on conventional material tags (empty by default — light up in packs). */
-    ALUMINIUM(96),
-    STAINLESSSTEEL(128),
-    TITANIUM(256),
-    TUNGSTENSTEEL(512),
+    ALUMINIUM(96, 5.0F, 4.0F),
+    STAINLESSSTEEL(128, 9.0F, 8.0F),
+    TITANIUM(256, 10.0F, 10.0F),
+    TUNGSTENSTEEL(512, 12.0F, 14.0F),
     /** Destroys fluid a little each tick (see {@link VoidTank}); small buffer capacity. */
-    VOID(8),
+    VOID(8, 5.0F, 6.0F),
     /** Dispenses fluid endlessly; capacity is nominal since it never actually drains. */
-    CREATIVE(1);
+    CREATIVE(1, 5.0F, 6.0F);
 
     /** Droplets per bucket — the canonical fluid unit (matches Fabric's {@code FluidConstants.BUCKET}). */
     public static final int DROPLETS_PER_BUCKET = 81_000;
@@ -44,9 +45,13 @@ public enum TankTier {
     public static final int DROPLETS_PER_BOTTLE = DROPLETS_PER_BUCKET / 3; // 27_000
 
     private final int buckets;
+    private final float hardness;
+    private final float blastResistance;
 
-    TankTier(int buckets) {
+    TankTier(int buckets, float hardness, float blastResistance) {
         this.buckets = buckets;
+        this.hardness = hardness;
+        this.blastResistance = blastResistance;
     }
 
     /** Capacity in whole buckets, as shown in the tank tooltip. */
@@ -57,5 +62,15 @@ public enum TankTier {
     /** Capacity in droplets, the unit fluid amounts are tracked in. */
     public long capacity() {
         return (long) buckets * DROPLETS_PER_BUCKET;
+    }
+
+    /** Block hardness (mining time) for this tier's tank. */
+    public float hardness() {
+        return hardness;
+    }
+
+    /** Explosion resistance for this tier's tank; obsidian is high enough to be blast-proof. */
+    public float blastResistance() {
+        return blastResistance;
     }
 }

--- a/core/src/test/java/com/indemnity83/irontanks/core/TankTierTest.java
+++ b/core/src/test/java/com/indemnity83/irontanks/core/TankTierTest.java
@@ -34,6 +34,19 @@ class TankTierTest {
     }
 
     @Test
+    void hardnessAndBlastResistanceFollowTheTierTable() {
+        // Tiers get tougher up the ladder; obsidian stays explosion-proof.
+        assertThat(TankTier.GLASS.hardness()).isEqualTo(0.3F);
+        assertThat(TankTier.GLASS.blastResistance()).isEqualTo(0.3F);
+        assertThat(TankTier.COPPER.hardness()).isEqualTo(4.0F);
+        assertThat(TankTier.DIAMOND.hardness()).isEqualTo(8.0F);
+        assertThat(TankTier.TUNGSTENSTEEL.hardness()).isEqualTo(12.0F);
+        assertThat(TankTier.TUNGSTENSTEEL.blastResistance()).isEqualTo(14.0F);
+        assertThat(TankTier.OBSIDIAN.hardness()).isEqualTo(50.0F);
+        assertThat(TankTier.OBSIDIAN.blastResistance()).isEqualTo(1200.0F);
+    }
+
+    @Test
     void bottleIsExactlyOneThirdOfABucket() {
         assertThat(TankTier.DROPLETS_PER_BOTTLE).isEqualTo(27_000);
         // Three bottles fill a bucket exactly — no rounding remainder in droplets.

--- a/core/src/test/java/com/indemnity83/irontanks/core/TankTierTest.java
+++ b/core/src/test/java/com/indemnity83/irontanks/core/TankTierTest.java
@@ -35,15 +35,36 @@ class TankTierTest {
 
     @Test
     void hardnessAndBlastResistanceFollowTheTierTable() {
-        // Tiers get tougher up the ladder; obsidian stays explosion-proof.
+        // Tiers get tougher up the ladder; obsidian stays explosion-proof. Locks the whole table
+        // so a regression in any single entry is caught.
         assertThat(TankTier.GLASS.hardness()).isEqualTo(0.3F);
         assertThat(TankTier.GLASS.blastResistance()).isEqualTo(0.3F);
         assertThat(TankTier.COPPER.hardness()).isEqualTo(4.0F);
+        assertThat(TankTier.COPPER.blastResistance()).isEqualTo(2.0F);
+        assertThat(TankTier.IRON.hardness()).isEqualTo(5.0F);
+        assertThat(TankTier.IRON.blastResistance()).isEqualTo(3.0F);
+        assertThat(TankTier.SILVER.hardness()).isEqualTo(6.0F);
+        assertThat(TankTier.SILVER.blastResistance()).isEqualTo(5.0F);
+        assertThat(TankTier.GOLD.hardness()).isEqualTo(7.0F);
+        assertThat(TankTier.GOLD.blastResistance()).isEqualTo(4.0F);
         assertThat(TankTier.DIAMOND.hardness()).isEqualTo(8.0F);
-        assertThat(TankTier.TUNGSTENSTEEL.hardness()).isEqualTo(12.0F);
-        assertThat(TankTier.TUNGSTENSTEEL.blastResistance()).isEqualTo(14.0F);
+        assertThat(TankTier.DIAMOND.blastResistance()).isEqualTo(6.0F);
         assertThat(TankTier.OBSIDIAN.hardness()).isEqualTo(50.0F);
         assertThat(TankTier.OBSIDIAN.blastResistance()).isEqualTo(1200.0F);
+        assertThat(TankTier.EMERALD.hardness()).isEqualTo(8.0F);
+        assertThat(TankTier.EMERALD.blastResistance()).isEqualTo(6.0F);
+        assertThat(TankTier.ALUMINIUM.hardness()).isEqualTo(5.0F);
+        assertThat(TankTier.ALUMINIUM.blastResistance()).isEqualTo(4.0F);
+        assertThat(TankTier.STAINLESSSTEEL.hardness()).isEqualTo(9.0F);
+        assertThat(TankTier.STAINLESSSTEEL.blastResistance()).isEqualTo(8.0F);
+        assertThat(TankTier.TITANIUM.hardness()).isEqualTo(10.0F);
+        assertThat(TankTier.TITANIUM.blastResistance()).isEqualTo(10.0F);
+        assertThat(TankTier.TUNGSTENSTEEL.hardness()).isEqualTo(12.0F);
+        assertThat(TankTier.TUNGSTENSTEEL.blastResistance()).isEqualTo(14.0F);
+        assertThat(TankTier.VOID.hardness()).isEqualTo(5.0F);
+        assertThat(TankTier.VOID.blastResistance()).isEqualTo(6.0F);
+        assertThat(TankTier.CREATIVE.hardness()).isEqualTo(5.0F);
+        assertThat(TankTier.CREATIVE.blastResistance()).isEqualTo(6.0F);
     }
 
     @Test

--- a/fabric/src/main/java/com/indemnity83/irontanks/fabric/content/IronTanksContent.java
+++ b/fabric/src/main/java/com/indemnity83/irontanks/fabric/content/IronTanksContent.java
@@ -60,10 +60,9 @@ public final class IronTanksContent {
         String name = tier.name().toLowerCase(Locale.ROOT) + "_tank";
 
         ResourceKey<Block> blockKey = ResourceKey.create(Registries.BLOCK, id(name));
-        float blastResistance = tier == TankTier.OBSIDIAN ? 1200.0F : 10.0F;
         BlockBehaviour.Properties properties = BlockBehaviour.Properties.of()
                 .setId(blockKey)
-                .strength(5.0F, blastResistance)
+                .strength(tier.hardness(), tier.blastResistance())
                 .sound(SoundType.METAL)
                 .noOcclusion()
                 .requiresCorrectToolForDrops();

--- a/neoforge/src/main/java/com/indemnity83/irontanks/neoforge/content/IronTanksContent.java
+++ b/neoforge/src/main/java/com/indemnity83/irontanks/neoforge/content/IronTanksContent.java
@@ -60,10 +60,9 @@ public final class IronTanksContent {
         String name = tier.name().toLowerCase(Locale.ROOT) + "_tank";
 
         ResourceKey<Block> blockKey = ResourceKey.create(Registries.BLOCK, id(name));
-        float blastResistance = tier == TankTier.OBSIDIAN ? 1200.0F : 10.0F;
         BlockBehaviour.Properties properties = BlockBehaviour.Properties.of()
                 .setId(blockKey)
-                .strength(5.0F, blastResistance)
+                .strength(tier.hardness(), tier.blastResistance())
                 .sound(SoundType.METAL)
                 .noOcclusion()
                 .requiresCorrectToolForDrops();


### PR DESCRIPTION
## Summary

Each tank tier now has its own **mining hardness** and **blast resistance**
instead of every tank sharing one flat value. Better materials are tougher to
break and survive bigger explosions; obsidian stays explosion-proof.

Implements #149 for the multiloader `mc/26.1` line (NeoForge + Fabric).

## The table

| Tier | Hardness | Blast |
|---|---|---|
| Glass | 0.3 | 0.3 |
| Copper | 4.0 | 2.0 |
| Iron | 5.0 | 3.0 |
| Silver | 6.0 | 5.0 |
| Gold | 7.0 | 4.0 |
| Diamond | 8.0 | 6.0 |
| Emerald | 8.0 | 6.0 |
| Aluminium | 5.0 | 4.0 |
| Stainless Steel | 9.0 | 8.0 |
| Titanium | 10.0 | 10.0 |
| Tungsten Steel | 12.0 | 14.0 |
| Obsidian | 50.0 | 1200 (explosion-proof) |

## How it's wired

The values live as data on `core/TankTier` (`hardness()` / `blastResistance()`),
so both loaders just read them when building the block properties — no per-loader
balance logic. A `core` test locks in the table.

## Notes

- Previously: flat `strength(5.0, 10.0)`, obsidian `1200`. Obsidian behaviour
  is unchanged; everything else is now tier-specific.
- `./gradlew build` green (core tests + both loader jars), `spotlessCheck` clean.
