### PR TITLE
feat: per-tier tank hardness and blast resistance

### DIFF
--- a/src/main/java/com/indemnity83/irontanks/common/core/Blocks.java
+++ b/src/main/java/com/indemnity83/irontanks/common/core/Blocks.java
@@ -4,6 +4,7 @@ import com.indemnity83.irontanks.IronTanks;
 import com.indemnity83.irontanks.common.blocks.CreativeTankBlock;
 import com.indemnity83.irontanks.common.blocks.StackableTankBlock;
 import com.indemnity83.irontanks.common.blocks.VoidTankBlock;
+import net.minecraft.block.Block;
 import net.minecraftforge.fml.common.registry.GameRegistry;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
@@ -49,11 +50,29 @@ public class Blocks {
     public static CreativeTankBlock creativeTank;
 
     public static void init() {
-        obsidianTank.setResistance(6000);
+        // Per-tier hardness (mining time) and resistance (blast resistance); obsidian stays blast-proof.
+        setStrength(copperTank, 4.0F, 2.0F);
+        setStrength(ironTank, 5.0F, 3.0F);
+        setStrength(silverTank, 6.0F, 5.0F);
+        setStrength(goldTank, 7.0F, 4.0F);
+        setStrength(diamondTank, 8.0F, 6.0F);
+        setStrength(emeraldTank, 8.0F, 6.0F);
+        setStrength(aluminiumTank, 5.0F, 4.0F);
+        setStrength(stainlessSteelTank, 9.0F, 8.0F);
+        setStrength(titaniumTank, 10.0F, 10.0F);
+        setStrength(tungstenSteelTank, 12.0F, 14.0F);
+        setStrength(obsidianTank, 50.0F, 1200.0F);
+        setStrength(voidTank, 5.0F, 6.0F);
+        setStrength(creativeTank, 5.0F, 6.0F);
 
         if (!IronTanksConfig.creativeTankBreakable) {
             creativeTank.setBlockUnbreakable();
         }
+    }
+
+    private static void setStrength(Block tank, float hardness, float resistance) {
+        tank.setHardness(hardness);
+        tank.setResistance(resistance);
     }
 
     @SideOnly(Side.CLIENT)


### PR DESCRIPTION
## Summary

Each tank tier now has its own **mining hardness** and **blast resistance**
instead of every tank sharing one flat value. Better materials are tougher to
break and survive bigger explosions; obsidian stays explosion-proof.

Implements #149 for the `mc/1.12.2` line.

## The table

| Tier | Hardness | Blast |
|---|---|---|
| Copper | 4.0 | 2.0 |
| Iron | 5.0 | 3.0 |
| Silver | 6.0 | 5.0 |
| Gold | 7.0 | 4.0 |
| Diamond | 8.0 | 6.0 |
| Emerald | 8.0 | 6.0 |
| Aluminium | 5.0 | 4.0 |
| Stainless Steel | 9.0 | 8.0 |
| Titanium | 10.0 | 10.0 |
| Tungsten Steel | 12.0 | 14.0 |
| Obsidian | 50.0 | 1200 (explosion-proof) |
| Void / Creative | 5.0 | 6.0 |

## Changes

- `Blocks.init()` now sets per-tier hardness + resistance for every tank
  (centralised where the obsidian override already lived). Previously a flat
  `setHardness(5.0)` / `setResistance(10.0)` with obsidian bumped to 6000.
- Obsidian is now 1200 (vanilla obsidian; still TNT/creeper-proof), matching the
  other branches.

Compiles clean (`./gradlew compileJava`).
