### PR TITLE
feat: per-tier tank hardness and blast resistance

### DIFF
--- a/src/main/java/com/indemnity83/irontank/block/BlockExtendedTank.java
+++ b/src/main/java/com/indemnity83/irontank/block/BlockExtendedTank.java
@@ -41,6 +41,7 @@ public class BlockExtendedTank extends BlockTank {
 		this.setBlockName(type.name);
 		this.setCreativeTab(IronTankTabs.MainTab);
 		this.setResistance(type.resistance);
+		this.setHardness(type.hardness);
 	}
 
 	public TileEntity createNewTileEntity(World world, int metadata) {

--- a/src/main/java/com/indemnity83/irontank/reference/TankType.java
+++ b/src/main/java/com/indemnity83/irontank/reference/TankType.java
@@ -24,18 +24,18 @@ import cpw.mods.fml.common.registry.GameRegistry;
  *
  */
 public enum TankType{
-    IRON(32, "irontank", Arrays.asList("ingotIron", "ingotRefinedIron"), Arrays.asList("tgtg0gtgt", "gggt4tggg"), 25/3F),
-    GOLD(48, "goldtank", Arrays.asList("ingotGold"), Arrays.asList("tgtg1gtgt", "gggt5tggg"), 25/3F),
-    DIAMOND(64, "diamondtank", Arrays.asList("gemDiamond"), Arrays.asList("gggt2tggg", "gggg5gttt"), 25/3F),
-    COPPER(27, "coppertank", Arrays.asList("ingotCopper"), Arrays.asList("tgtg0gtgt"), 25/3F),
-    SILVER(43, "silvertank", Arrays.asList("ingotSilver"), Arrays.asList("tgtg4gtgt", "gggt1tggg"), 25/3F),
-    OBSIDIAN(64, "obsidiantank", Arrays.asList("obsidian"), Arrays.asList("tgtg3gtgt"), 6000000.0F),
-    GLASS(0, "", Arrays.asList("blockGlass"), Arrays.asList(""), 0f),
-	EMERALD(96, "emeraldtank", Arrays.asList("gemEmerald"), Arrays.asList("gggt3tggg"), 25/3F),
-	ALUMINIUM(96, "aluminiumtank", Arrays.asList("ingotAluminium", "ingotAluminum"), Arrays.asList("gggt3tggg"), 25/3F),
-	STAINLESSSTEEL(128, "stainlesssteeltank", Arrays.asList("ingotStainlessSteel"), Arrays.asList("gggt8tggg", "gggt7tggg"), 25/3F),
-	TITANIUM(256, "titaniumtank", Arrays.asList("ingotTitanium"), Arrays.asList("gggt9tggg"), 25/3F),
-	TUNGSTENSTEEL(512, "tungstensteeltank", Arrays.asList("ingotTungstenSteel"), Arrays.asList("gggtztggg"), 25/3F);
+    IRON(32, "irontank", Arrays.asList("ingotIron", "ingotRefinedIron"), Arrays.asList("tgtg0gtgt", "gggt4tggg"), 3.0F, 5.0F),
+    GOLD(48, "goldtank", Arrays.asList("ingotGold"), Arrays.asList("tgtg1gtgt", "gggt5tggg"), 4.0F, 7.0F),
+    DIAMOND(64, "diamondtank", Arrays.asList("gemDiamond"), Arrays.asList("gggt2tggg", "gggg5gttt"), 6.0F, 8.0F),
+    COPPER(27, "coppertank", Arrays.asList("ingotCopper"), Arrays.asList("tgtg0gtgt"), 2.0F, 4.0F),
+    SILVER(43, "silvertank", Arrays.asList("ingotSilver"), Arrays.asList("tgtg4gtgt", "gggt1tggg"), 5.0F, 6.0F),
+    OBSIDIAN(64, "obsidiantank", Arrays.asList("obsidian"), Arrays.asList("tgtg3gtgt"), 1200.0F, 50.0F),
+    GLASS(0, "", Arrays.asList("blockGlass"), Arrays.asList(""), 0.3F, 0.3F),
+	EMERALD(96, "emeraldtank", Arrays.asList("gemEmerald"), Arrays.asList("gggt3tggg"), 6.0F, 8.0F),
+	ALUMINIUM(96, "aluminiumtank", Arrays.asList("ingotAluminium", "ingotAluminum"), Arrays.asList("gggt3tggg"), 4.0F, 5.0F),
+	STAINLESSSTEEL(128, "stainlesssteeltank", Arrays.asList("ingotStainlessSteel"), Arrays.asList("gggt8tggg", "gggt7tggg"), 8.0F, 9.0F),
+	TITANIUM(256, "titaniumtank", Arrays.asList("ingotTitanium"), Arrays.asList("gggt9tggg"), 10.0F, 10.0F),
+	TUNGSTENSTEEL(512, "tungstensteeltank", Arrays.asList("ingotTungstenSteel"), Arrays.asList("gggtztggg"), 14.0F, 12.0F);
 
 	/**
 	 * fluid capacity of the tank type
@@ -63,12 +63,18 @@ public enum TankType{
 	 */
 	public final float resistance;
 
-	TankType(int capacity, String name, List<String> materials, List<String> recipes, float resistance) {
+	/**
+	 * Hardness (mining time) of the tank type
+	 */
+	public final float hardness;
+
+	TankType(int capacity, String name, List<String> materials, List<String> recipes, float resistance, float hardness) {
 		this.capacity = capacity;
 		this.name = name;
 		this.materials = new ArrayList<String>();
 		this.recipes = new ArrayList<String>();
 		this.resistance = resistance;
+		this.hardness = hardness;
 
 		this.materials.addAll(materials);
 		this.recipes.addAll(recipes);

--- a/src/main/java/com/indemnity83/irontank/reference/TankType.java
+++ b/src/main/java/com/indemnity83/irontank/reference/TankType.java
@@ -31,11 +31,11 @@ public enum TankType{
     SILVER(43, "silvertank", Arrays.asList("ingotSilver"), Arrays.asList("tgtg4gtgt", "gggt1tggg"), 5.0F, 6.0F),
     OBSIDIAN(64, "obsidiantank", Arrays.asList("obsidian"), Arrays.asList("tgtg3gtgt"), 1200.0F, 50.0F),
     GLASS(0, "", Arrays.asList("blockGlass"), Arrays.asList(""), 0.3F, 0.3F),
-	EMERALD(96, "emeraldtank", Arrays.asList("gemEmerald"), Arrays.asList("gggt3tggg"), 6.0F, 8.0F),
-	ALUMINIUM(96, "aluminiumtank", Arrays.asList("ingotAluminium", "ingotAluminum"), Arrays.asList("gggt3tggg"), 4.0F, 5.0F),
-	STAINLESSSTEEL(128, "stainlesssteeltank", Arrays.asList("ingotStainlessSteel"), Arrays.asList("gggt8tggg", "gggt7tggg"), 8.0F, 9.0F),
-	TITANIUM(256, "titaniumtank", Arrays.asList("ingotTitanium"), Arrays.asList("gggt9tggg"), 10.0F, 10.0F),
-	TUNGSTENSTEEL(512, "tungstensteeltank", Arrays.asList("ingotTungstenSteel"), Arrays.asList("gggtztggg"), 14.0F, 12.0F);
+    EMERALD(96, "emeraldtank", Arrays.asList("gemEmerald"), Arrays.asList("gggt3tggg"), 6.0F, 8.0F),
+    ALUMINIUM(96, "aluminiumtank", Arrays.asList("ingotAluminium", "ingotAluminum"), Arrays.asList("gggt3tggg"), 4.0F, 5.0F),
+    STAINLESSSTEEL(128, "stainlesssteeltank", Arrays.asList("ingotStainlessSteel"), Arrays.asList("gggt8tggg", "gggt7tggg"), 8.0F, 9.0F),
+    TITANIUM(256, "titaniumtank", Arrays.asList("ingotTitanium"), Arrays.asList("gggt9tggg"), 10.0F, 10.0F),
+    TUNGSTENSTEEL(512, "tungstensteeltank", Arrays.asList("ingotTungstenSteel"), Arrays.asList("gggtztggg"), 14.0F, 12.0F);
 
 	/**
 	 * fluid capacity of the tank type


### PR DESCRIPTION
## Summary

Each tank tier now has its own **mining hardness** and **blast resistance**.
Previously every tank shared a flat resistance (~8.3) with no hardness set;
now better materials are tougher to break and survive bigger explosions.
Obsidian stays explosion-proof.

Implements #149 for the `mc/1.7.10` line.

## The table

| Tier | Hardness | Resistance |
|---|---|---|
| Copper | 4.0 | 2.0 |
| Iron | 5.0 | 3.0 |
| Silver | 6.0 | 5.0 |
| Gold | 7.0 | 4.0 |
| Diamond | 8.0 | 6.0 |
| Emerald | 8.0 | 6.0 |
| Aluminium | 5.0 | 4.0 |
| Stainless Steel | 9.0 | 8.0 |
| Titanium | 10.0 | 10.0 |
| Tungsten Steel | 12.0 | 14.0 |
| Obsidian | 50.0 | 1200 (explosion-proof) |

## Changes

- `TankType` gains a `hardness` field alongside `resistance`, with per-tier
  values (replacing the flat `25/3F`).
- `BlockExtendedTank` now calls `setHardness(type.hardness)` as well as
  `setResistance(type.resistance)`.
- Obsidian resistance normalised from 6,000,000 to 1200 (vanilla obsidian;
  still TNT/creeper-proof), matching the other branches.

Compiles clean (`./gradlew compileJava`).
