### PR TITLE
fix: gold and diamond upgrade recipes produce the wrong item

### DIFF
--- a/src/main/java/com/indemnity83/irontanks/common/core/Recipes.java
+++ b/src/main/java/com/indemnity83/irontanks/common/core/Recipes.java
@@ -219,7 +219,7 @@ public class Recipes {
             builder.map('g', "paneGlassColorless");
             builder.map('s', "ingotGold");
             builder.map('t', "gemDiamond");
-            builder.setResult(new ItemStack(Items.glassIronUpgrade));
+            builder.setResult(new ItemStack(Items.goldDiamondUpgrade));
             builder.register();
             builder.registerRotated();
         }
@@ -232,7 +232,7 @@ public class Recipes {
             builder.map('g', "paneGlassColorless");
             builder.map('s', "gemDiamond");
             builder.map('t', "gemEmerald");
-            builder.setResult(new ItemStack(Items.glassIronUpgrade));
+            builder.setResult(new ItemStack(Items.diamondEmeraldUpgrade));
             builder.register();
             builder.registerRotated();
         }


### PR DESCRIPTION
## Summary

Fixes two upgrade-item recipes on `mc/1.11.2` that produced the wrong item.

In `Recipes.java`, the **Gold → Diamond** and **Diamond → Emerald** upgrade
recipes both called `setResult(... glassIronUpgrade)` — a copy-paste slip — so:

- the Gold→Diamond and Diamond→Emerald upgrade items had **no crafting recipe**, and
- `glass_iron_upgrade` had **three** redundant recipes.

Fixes #160.

## Changes

- Gold→Diamond recipe now results in `goldDiamondUpgrade`.
- Diamond→Emerald recipe now results in `diamondEmeraldUpgrade`.

(The legitimate `glass_iron_upgrade` recipe is unchanged.)

Compiles clean (`./gradlew compileJava`).
