### PR TITLE
fix: correct Russian creative tank tooltip spelling

### DIFF
--- a/src/main/resources/assets/irontanks/lang/ru_RU.lang
+++ b/src/main/resources/assets/irontanks/lang/ru_RU.lang
@@ -33,5 +33,5 @@ tile.irontanks.tungstensteel_tank.name=Вольфрамостальная цис
 # Misc localizations
 irontanks.tooltip.capacity=Удерживает %s ведер
 irontanks.tooltip.void_tank=Уничтожает жидкости
-irontanks.tooltip.creative_tank=Хранит неограниченое кол-во жидкости
+irontanks.tooltip.creative_tank=Хранит неограниченное кол-во жидкости
 


### PR DESCRIPTION
## Summary

Corrects a spelling error in the Russian Creative Tank tooltip that Russian-speaking players would see in-game.

## Changes

- `ru_RU.lang`: `неограниченое` → `неограниченное` (the correct spelling of "unlimited") in `irontanks.tooltip.creative_tank`.

## Notes

- Pre-existing typo, unrelated to the recent translation additions in #173 — surfaced during that review.
- The same typo exists on `mc/1.11.2` and is being fixed there in a parallel PR. `mc/26.1` already has the correct spelling; `mc/1.7.10` has no Russian Creative tooltip.