### PR TITLE
fix: correct Russian creative tank tooltip spelling

### DIFF
--- a/src/main/resources/assets/irontanks/lang/ru_RU.lang
+++ b/src/main/resources/assets/irontanks/lang/ru_RU.lang
@@ -24,4 +24,4 @@ tile.irontanks.creative_tank.name=Креативная цистерна
 # Misc localizations
 irontanks.tooltip.capacity=Удерживает %s ведер
 irontanks.tooltip.void_tank=Уничтожает жидкости
-irontanks.tooltip.creative_tank=Хранит неограниченое кол-во жидкости
+irontanks.tooltip.creative_tank=Хранит неограниченное кол-во жидкости


### PR DESCRIPTION
## Summary

Corrects a spelling error in the Russian Creative Tank tooltip that Russian-speaking players would see in-game.

## Changes

- `ru_RU.lang`: `неограниченое` → `неограниченное` (the correct spelling of "unlimited") in `irontanks.tooltip.creative_tank`.

## Notes

- Pre-existing typo, surfaced during the #173 translation review. The same fix is going into `mc/1.12.2` (#208).